### PR TITLE
add upload validation status URL to upload debug messages

### DIFF
--- a/BridgeSDK/BridgeAPI/SBBUploadManager.m
+++ b/BridgeSDK/BridgeAPI/SBBUploadManager.m
@@ -34,6 +34,7 @@
 #import "NSData+SBBAdditions.h"
 #import "SBBComponentManager.h"
 #import "SBBAuthManager.h"
+#import "SBBNetworkManagerInternal.h"
 #import "SBBObjectManager.h"
 #import "SBBUploadSession.h"
 #import "SBBUploadRequest.h"
@@ -431,9 +432,15 @@ static NSString *kUploadSessionsKey = @"SBBUploadSessionsKey";
     [self.networkManager post:ref headers:headers parameters:nil completion:^(NSURLSessionDataTask *task, id responseObject, NSError *error) {
 #if DEBUG
       if (error) {
-        NSLog(@"Error calling upload complete for URL %@:\n%@", ref, error);
+        NSLog(@"Error calling upload complete for upload ID %@:\n%@", uploadSession.id, error);
       } else {
-        NSLog(@"Successfully called upload complete for URL %@", ref);
+        NSString* uploadStatusUrlString = nil;
+        if ([self.networkManager isKindOfClass:[SBBNetworkManager class]]) {
+          NSString* relativeUrl = [NSString stringWithFormat:@"/api/v1/upload/%@/status", uploadSession.id];
+          NSURL* url = [(SBBNetworkManager*) self.networkManager URLForRelativeorAbsoluteURLString:relativeUrl];
+          uploadStatusUrlString = [url absoluteString];
+        }
+        NSLog(@"Successfully called upload complete for upload ID %@, check status at %@", uploadSession.id, uploadStatusUrlString);
       }
 #endif
 

--- a/BridgeSDK/Networking/SBBNetworkManagerInternal.h
+++ b/BridgeSDK/Networking/SBBNetworkManagerInternal.h
@@ -56,4 +56,6 @@ extern NSString *kAPIPrefix;
 - (void)handleHTTPError:(NSError *)error task:(NSURLSessionDataTask *)task retryObject:(APCNetworkRetryObject *)retryObject;
 - (NSDictionary *)headersPreparedForRetry:(NSDictionary *)headers;
 
+- (NSURL *) URLForRelativeorAbsoluteURLString: (NSString*) URLString;
+
 @end


### PR DESCRIPTION
The upload debug messages should contain a link to the upload status, to make the upload feedback loop even easier. The debug message will look something like
Successfully called upload complete for upload ID 280dd6f4-6fb2-45b5-846a-9d582e30196b, check status at https://webservices-staging.sagebridge.org/api/v1/upload/280dd6f4-6fb2-45b5-846a-9d582e30196b/status

This also involves making URLForRelativeorAbsoluteURLString available through SBBNetworkManagerInternal.h.

Testing done:
* ran the BridgeSDK sample app, uploaded a file, verified log messages in console logs