### PR TITLE
SBBProfileManager -> SBBUserManager rename

### DIFF
--- a/BridgeSDK/BridgeSDK.h
+++ b/BridgeSDK/BridgeSDK.h
@@ -49,7 +49,7 @@ extern const unsigned char BridgeSDKVersionString[];
 #import <BridgeSDK/SBBComponent.h>
 #import <BridgeSDK/SBBComponentManager.h>
 #import <BridgeSDK/SBBConsentManager.h>
-#import <BridgeSDK/SBBProfileManager.h>
+#import <BridgeSDK/SBBUserManager.h>
 #import <BridgeSDK/SBBObjectManager.h>
 #import <BridgeSDK/SBBNetworkManager.h>
 #import <BridgeSDK/SBBScheduleManager.h>


### PR DESCRIPTION
I think this is a rename that slipped through earlier? Not sure why it didn't show up as a problem until now.