### PR TITLE
Identify iPhone 6S/6S+

### DIFF
--- a/BridgeSDK/BridgeAPI/Categories/UIDevice+Hardware.h
+++ b/BridgeSDK/BridgeAPI/Categories/UIDevice+Hardware.h
@@ -19,6 +19,8 @@
 #define IPHONE_5S_NAMESTRING            @"iPhone 5S"
 #define IPHONE_6_NAMESTRING             @"iPhone 6"
 #define IPHONE_6PLUS_NAMESTRING         @"iPhone 6+"
+#define IPHONE_6S_NAMESTRING            @"iPhone 6S"
+#define IPHONE_6SPLUS_NAMESTRING        @"iPhone 6S+"
 #define IPHONE_UNKNOWN_NAMESTRING       @"Unknown iPhone"
 
 #define IPOD_1G_NAMESTRING              @"iPod touch 1G"
@@ -62,6 +64,8 @@ typedef enum {
   UIDevice5SiPhone,
   UIDevice6iPhone,
   UIDevice6PlusiPhone,
+  UIDevice6SiPhone,
+  UIDevice6SPlusiPhone,
   
   UIDevice1GiPod,
   UIDevice2GiPod,

--- a/BridgeSDK/BridgeAPI/Categories/UIDevice+Hardware.m
+++ b/BridgeSDK/BridgeAPI/Categories/UIDevice+Hardware.m
@@ -163,7 +163,9 @@
   if ([platform hasPrefix:@"iPhone5"])            return UIDevice5iPhone;
   if ([platform hasPrefix:@"iPhone6"])            return UIDevice5SiPhone;
   if ([platform isEqualToString:@"iPhone7,1"])    return UIDevice6PlusiPhone;
-  if ([platform isEqualToString:@"iPhone1,2"])    return UIDevice6iPhone;
+  if ([platform isEqualToString:@"iPhone7,2"])    return UIDevice6iPhone;
+  if ([platform isEqualToString:@"iPhone8,1"])    return UIDevice6SiPhone;
+  if ([platform isEqualToString:@"iPhone8,2"])    return UIDevice6SPlusiPhone;
   
   // iPod
   if ([platform hasPrefix:@"iPod1"])              return UIDevice1GiPod;
@@ -209,6 +211,8 @@
     case UIDevice5SiPhone: return IPHONE_5S_NAMESTRING;
     case UIDevice6iPhone: return IPHONE_6_NAMESTRING;
     case UIDevice6PlusiPhone: return IPHONE_6PLUS_NAMESTRING;
+    case UIDevice6SiPhone: return IPHONE_6S_NAMESTRING;
+    case UIDevice6SPlusiPhone: return IPHONE_6SPLUS_NAMESTRING;
     case UIDeviceUnknowniPhone: return IPHONE_UNKNOWN_NAMESTRING;
       
     case UIDevice1GiPod: return IPOD_1G_NAMESTRING;


### PR DESCRIPTION
for UserAgent strings and logging (also fix bug identifying iPhone 6)