### PR TITLE
Fix consent and activities to pass int. tests

### DIFF
--- a/BridgeSDK.xcodeproj/project.pbxproj
+++ b/BridgeSDK.xcodeproj/project.pbxproj
@@ -719,11 +719,11 @@
 			children = (
 				80314E8D1B56FF4700D029D3 /* SBBBridgeAPIIntegrationTestCase.h */,
 				80314E8B1B56FE7900D029D3 /* SBBBridgeAPIIntegrationTestCase.m */,
+				80B7868B1B5BF8350029EAE6 /* SBBActivityManagerIntegrationTests.m */,
 				80314E8E1B57162100D029D3 /* SBBAuthManagerIntegrationTests.m */,
 				80B786811B5AB1DC0029EAE6 /* SBBConsentManagerIntegrationTests.m */,
 				80B786851B5BF7860029EAE6 /* SBBScheduleManagerIntegrationTests.m */,
 				80B786871B5BF79C0029EAE6 /* SBBSurveyManagerIntegrationTests.m */,
-				80B7868B1B5BF8350029EAE6 /* SBBActivityManagerIntegrationTests.m */,
 				80B786891B5BF7AF0029EAE6 /* SBBUploadManagerIntegrationTests.m */,
 				80B786831B5BF71D0029EAE6 /* SBBUserManagerIntegrationTests.m */,
 				807AE27E1B5ED921002588BB /* TestAdminAuthDelegate.h */,

--- a/BridgeSDK/BridgeAPI/Categories/NSDate+SBBAdditions.m
+++ b/BridgeSDK/BridgeAPI/Categories/NSDate+SBBAdditions.m
@@ -78,7 +78,7 @@
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         formatter = [[NSDateFormatter alloc] init];
-        [formatter setDateFormat:@"ZZZZZ"];
+        [formatter setDateFormat:@"xxx"]; // ZZZZZ gives 'Z' for GMT-0, xxx gives '+00:00' but otherwise identical
         NSLocale *enUSPOSIXLocale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
         [formatter setLocale:enUSPOSIXLocale];
     });

--- a/BridgeSDK/BridgeAPI/SBBConsentManager.m
+++ b/BridgeSDK/BridgeAPI/SBBConsentManager.m
@@ -138,7 +138,7 @@ NSString * const kSBBMimeTypePng = @"image/png";
     NSMutableDictionary *headers = [NSMutableDictionary dictionary];
     [self.authManager addAuthHeaderToHeaders:headers];
 
-    NSDictionary *parameters = reason.length ? @{@"reason": reason} : nil;
+    NSDictionary *parameters = reason.length ? @{@"reason": reason} : @{};
     return [self.networkManager post:kSBBConsentWithdrawAPI
                              headers:headers
                           parameters:parameters

--- a/BridgeSDK/Networking/SBBNetworkManager.m
+++ b/BridgeSDK/Networking/SBBNetworkManager.m
@@ -121,6 +121,8 @@ NSString *kAPIPrefix = @"webservices";
 @property (nonatomic, strong) NSMutableDictionary *uploadCompletionHandlers;
 @property (nonatomic, strong) NSMutableDictionary *downloadCompletionHandlers;
 
+@property (nonatomic, strong) NSMutableCharacterSet *URLQueryKeysAndValuesAllowedCharacterSet;
+
 @end
 
 @implementation SBBNetworkManager
@@ -229,6 +231,16 @@ NSString *kAPIPrefix = @"webservices";
         }
     }
     return self;
+}
+
+- (NSCharacterSet *)URLQueryKeysAndValuesAllowedCharacterSet
+{
+    if (!_URLQueryKeysAndValuesAllowedCharacterSet) {
+        _URLQueryKeysAndValuesAllowedCharacterSet = [[NSCharacterSet URLQueryAllowedCharacterSet] mutableCopy];
+        [_URLQueryKeysAndValuesAllowedCharacterSet removeCharactersInString:@"&+=?"];
+    }
+
+    return _URLQueryKeysAndValuesAllowedCharacterSet;
 }
 
 - (NSURLSession *)mainSession
@@ -482,8 +494,8 @@ NSString *kAPIPrefix = @"webservices";
     
     if (valueString) {
       NSString *qParam = [NSString stringWithFormat:@"%@=%@",
-                          [param stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]],
-                          [valueString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]]];
+                          [param stringByAddingPercentEncodingWithAllowedCharacters:self.URLQueryKeysAndValuesAllowedCharacterSet],
+                          [valueString stringByAddingPercentEncodingWithAllowedCharacters:self.URLQueryKeysAndValuesAllowedCharacterSet]];
       [queryParams addObject:qParam];
     }
   }


### PR DESCRIPTION
also test other time zone offsets besides PST for scheduled activities API