### PR TITLE
BRIDGE-652 Kill switch for old versions

### DIFF
--- a/BridgeSDK/BridgeAPI/Categories/NSError+SBBAdditions.m
+++ b/BridgeSDK/BridgeAPI/Categories/NSError+SBBAdditions.m
@@ -160,7 +160,8 @@
 
 + (NSError *)generateSBBObjectNotExpectedClassErrorForObject:(id)object expectedClass:(Class)expectedClass
 {
-  NSString *localizedFormat = NSLocalizedString(@"Object '%1$@' is of class %2$@, expected class %3$@", @"Error Description");
+  NSString *localizedFormat = NSLocalizedString(@"Object '%1$@' is of class %2$@, expected class %3$@",
+                                                @"Error Description: Object is not of expected class. object description=$1, actual class=$2, expected class=$3");
   NSString *desc = [NSString stringWithFormat:localizedFormat, object, NSStringFromClass([object class]), NSStringFromClass(expectedClass)];
   return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeObjectNotExpectedClass userInfo:@{NSLocalizedDescriptionKey: desc}];
 }

--- a/BridgeSDK/BridgeAPI/Categories/NSError+SBBAdditions.m
+++ b/BridgeSDK/BridgeAPI/Categories/NSError+SBBAdditions.m
@@ -39,20 +39,20 @@
 {
     NSError * retError;
     if (!internetConnected) {
-        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBInternetNotConnected
+        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeInternetNotConnected
                                    userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Internet Not Connected",
                                                                                            @"Error Description: Internet not connected"),
                                               SBB_ORIGINAL_ERROR_KEY: urlError}];
     }
     else if (!isServerReachable) {
-        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBServerNotReachable
+        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeServerNotReachable
                                    userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Backend Server Not Reachable",
                                                                                            @"Error Description: Server not reachable"),
                                               SBB_ORIGINAL_ERROR_KEY: urlError}];
     }
     else
     {
-        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBUnknownError
+        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeUnknownError
                                    userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Unknown Network Error",
                                                                                            @"Error Description: Unknown network error"),
                                               SBB_ORIGINAL_ERROR_KEY: urlError}];
@@ -84,9 +84,17 @@
     if (statusCode == 401) {
         retError = [self SBBNotAuthenticatedError];
     }
+    else if (statusCode == 410)
+    {
+        NSString *localizedDescription = NSLocalizedString(@"Your version of this app is no longer supported. Please visit the app store to update your app.",
+                                                           @"Error Description: App requires upgrade");
+        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeUnsupportedAppVersion
+                                   userInfo:@{NSLocalizedDescriptionKey: localizedDescription,
+                                              SBB_ORIGINAL_ERROR_KEY: foundationObject}];
+    }
     else if (statusCode == 412)
     {
-        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBServerPreconditionNotMet
+        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeServerPreconditionNotMet
                                    userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Client not consented",
                                                                                            @"Error Description: Client not consented"),
                                               SBB_ORIGINAL_ERROR_KEY: foundationObject}];
@@ -99,7 +107,7 @@
                                               SBB_ORIGINAL_ERROR_KEY: foundationObject}];
     }
     else if (statusCode == 503) {
-        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBServerUnderMaintenance
+        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeServerUnderMaintenance
                                    userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Backend Server Under Maintenance.",
                                                                                            @"Error Description: Backend Server Under Maintenance"),
                                               SBB_ORIGINAL_ERROR_KEY: foundationObject}];
@@ -116,14 +124,14 @@
 
 + (NSError *)SBBNoCredentialsError
 {
-  return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBNoCredentialsAvailable
+  return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeNoCredentialsAvailable
                          userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"No user login credentials available. Please sign in.",
                                                                                  @"Error Description: missing login credentials")}];
 }
 
 + (NSError *)SBBNotAuthenticatedError
 {
-  return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBServerNotAuthenticated
+  return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeServerNotAuthenticated
                          userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Server says: not authenticated. Please authenticate.",
                                                                                  @"Error Description: not authenticated")}];
 }
@@ -132,7 +140,7 @@
 {
   NSString *localizedFormat = NSLocalizedString(@"Not a valid file URL:\n%@", @"Error Description: not a valid url");
   NSString *desc = [NSString stringWithFormat:localizedFormat, url];
-  return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBNotAFileURL
+  return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeNotAFileURL
                          userInfo:@{NSLocalizedDescriptionKey: desc}];
 }
 
@@ -140,21 +148,21 @@
 {
   NSString *localizedFormat = NSLocalizedString(@"Error copying file at URL to temp file:\n%@", @"Error Description: error copying file");
   NSString *desc = [NSString stringWithFormat:localizedFormat, url];
-  return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBTempFileError userInfo:@{NSLocalizedDescriptionKey: desc}];
+  return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeTempFileError userInfo:@{NSLocalizedDescriptionKey: desc}];
 }
 
 + (NSError *)generateSBBTempFileReadErrorForURL:(NSURL *)url
 {
   NSString *localizedFormat = NSLocalizedString(@"Error reading temp file for original file URL:\n%@", @"Error Description: error reading temp file");
   NSString *desc = [NSString stringWithFormat:localizedFormat, url];
-  return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBTempFileError userInfo:@{NSLocalizedDescriptionKey: desc}];
+  return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeTempFileError userInfo:@{NSLocalizedDescriptionKey: desc}];
 }
 
 + (NSError *)generateSBBObjectNotExpectedClassErrorForObject:(id)object expectedClass:(Class)expectedClass
 {
   NSString *localizedFormat = NSLocalizedString(@"Object '%1$@' is of class %2$@, expected class %3$@", @"Error Description");
   NSString *desc = [NSString stringWithFormat:localizedFormat, object, NSStringFromClass([object class]), NSStringFromClass(expectedClass)];
-  return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBObjectNotExpectedClass userInfo:@{NSLocalizedDescriptionKey: desc}];
+  return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeObjectNotExpectedClass userInfo:@{NSLocalizedDescriptionKey: desc}];
 }
 
 /*********************************************************************************/

--- a/BridgeSDK/BridgeAPI/Categories/NSError+SBBAdditions.m
+++ b/BridgeSDK/BridgeAPI/Categories/NSError+SBBAdditions.m
@@ -39,14 +39,23 @@
 {
     NSError * retError;
     if (!internetConnected) {
-        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBInternetNotConnected userInfo:@{NSLocalizedDescriptionKey: @"Internet Not Connected", SBB_ORIGINAL_ERROR_KEY: urlError}];
+        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBInternetNotConnected
+                                   userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Internet Not Connected",
+                                                                                           @"Error Description: Internet not connected"),
+                                              SBB_ORIGINAL_ERROR_KEY: urlError}];
     }
     else if (!isServerReachable) {
-        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBServerNotReachable userInfo:@{NSLocalizedDescriptionKey: @"Backend Server Not Reachable",SBB_ORIGINAL_ERROR_KEY: urlError}];
+        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBServerNotReachable
+                                   userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Backend Server Not Reachable",
+                                                                                           @"Error Description: Server not reachable"),
+                                              SBB_ORIGINAL_ERROR_KEY: urlError}];
     }
     else
     {
-        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBUnknownError userInfo:@{NSLocalizedDescriptionKey: @"Unknown Network Error",SBB_ORIGINAL_ERROR_KEY: urlError}];
+        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBUnknownError
+                                   userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Unknown Network Error",
+                                                                                           @"Error Description: Unknown network error"),
+                                              SBB_ORIGINAL_ERROR_KEY: urlError}];
     }
     return retError;
 }
@@ -77,51 +86,74 @@
     }
     else if (statusCode == 412)
     {
-        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBServerPreconditionNotMet userInfo:@{NSLocalizedDescriptionKey: @"Client not consented", SBB_ORIGINAL_ERROR_KEY: foundationObject}];
+        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBServerPreconditionNotMet
+                                   userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Client not consented",
+                                                                                           @"Error Description: Client not consented"),
+                                              SBB_ORIGINAL_ERROR_KEY: foundationObject}];
     }
     else if (NSLocationInRange(statusCode, NSMakeRange(400, 99))) {
-        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:statusCode userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Client Error: %@. Please contact customer support.", @(statusCode)],  SBB_ORIGINAL_ERROR_KEY: foundationObject}];
+        NSString *localizedFormat = NSLocalizedString(@"Client Error: %@. Please contact customer support.",
+                                                      @"Error Description: Unknown client app error");
+        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:statusCode
+                                   userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:localizedFormat, @(statusCode)],
+                                              SBB_ORIGINAL_ERROR_KEY: foundationObject}];
     }
     else if (statusCode == 503) {
-        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBServerUnderMaintenance userInfo:@{NSLocalizedDescriptionKey: @"Backend Server Under Maintenance.", SBB_ORIGINAL_ERROR_KEY: foundationObject}];
+        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBServerUnderMaintenance
+                                   userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Backend Server Under Maintenance.",
+                                                                                           @"Error Description: Backend Server Under Maintenance"),
+                                              SBB_ORIGINAL_ERROR_KEY: foundationObject}];
     }
     else if (NSLocationInRange(statusCode, NSMakeRange(500, 99))) {
-        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:statusCode userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Backend Server Error: %@. Please contact customer support.", @(statusCode)], SBB_ORIGINAL_ERROR_KEY: foundationObject}];
+        NSString *localizedFormat = NSLocalizedString(@"Backend Server Error: %@. Please contact customer support.",
+                                                      @"Error Description: Unknown server error");
+        retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:statusCode
+                                   userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:localizedFormat, @(statusCode)],
+                                              SBB_ORIGINAL_ERROR_KEY: foundationObject}];
     }
     return retError;
 }
 
 + (NSError *)SBBNoCredentialsError
 {
-  return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBNoCredentialsAvailable userInfo:@{NSLocalizedDescriptionKey: @"No user login credentials available. Please sign in."}];
+  return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBNoCredentialsAvailable
+                         userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"No user login credentials available. Please sign in.",
+                                                                                 @"Error Description: missing login credentials")}];
 }
 
 + (NSError *)SBBNotAuthenticatedError
 {
-  return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBServerNotAuthenticated userInfo:@{NSLocalizedDescriptionKey: @"Server says: not authenticated. Please authenticate."}];
+  return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBServerNotAuthenticated
+                         userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Server says: not authenticated. Please authenticate.",
+                                                                                 @"Error Description: not authenticated")}];
 }
 
 + (NSError *)generateSBBNotAFileURLErrorForURL:(NSURL *)url
 {
-  NSString *desc = [NSString stringWithFormat:@"Not a valid file URL:\n%@", url];
-  return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBNotAFileURL userInfo:@{NSLocalizedDescriptionKey: desc}];
+  NSString *localizedFormat = NSLocalizedString(@"Not a valid file URL:\n%@", @"Error Description: not a valid url");
+  NSString *desc = [NSString stringWithFormat:localizedFormat, url];
+  return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBNotAFileURL
+                         userInfo:@{NSLocalizedDescriptionKey: desc}];
 }
 
 + (NSError *)generateSBBTempFileErrorForURL:(NSURL *)url
 {
-  NSString *desc = [NSString stringWithFormat:@"Error copying file at URL to temp file:\n%@", url];
+  NSString *localizedFormat = NSLocalizedString(@"Error copying file at URL to temp file:\n%@", @"Error Description: error copying file");
+  NSString *desc = [NSString stringWithFormat:localizedFormat, url];
   return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBTempFileError userInfo:@{NSLocalizedDescriptionKey: desc}];
 }
 
 + (NSError *)generateSBBTempFileReadErrorForURL:(NSURL *)url
 {
-  NSString *desc = [NSString stringWithFormat:@"Error reading temp file for original file URL:\n%@", url];
+  NSString *localizedFormat = NSLocalizedString(@"Error reading temp file for original file URL:\n%@", @"Error Description: error reading temp file");
+  NSString *desc = [NSString stringWithFormat:localizedFormat, url];
   return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBTempFileError userInfo:@{NSLocalizedDescriptionKey: desc}];
 }
 
 + (NSError *)generateSBBObjectNotExpectedClassErrorForObject:(id)object expectedClass:(Class)expectedClass
 {
-  NSString *desc = [NSString stringWithFormat:@"Object '%@' is of class %@, expected class %@", object, NSStringFromClass([object class]), NSStringFromClass(expectedClass)];
+  NSString *localizedFormat = NSLocalizedString(@"Object '%1$@' is of class %2$@, expected class %3$@", @"Error Description");
+  NSString *desc = [NSString stringWithFormat:localizedFormat, object, NSStringFromClass([object class]), NSStringFromClass(expectedClass)];
   return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:kSBBObjectNotExpectedClass userInfo:@{NSLocalizedDescriptionKey: desc}];
 }
 

--- a/BridgeSDK/Networking/SBBErrors.h
+++ b/BridgeSDK/Networking/SBBErrors.h
@@ -34,6 +34,30 @@
 #define SBB_ERROR_DOMAIN @"org.sagebase.error_domain"
 #define SBB_ORIGINAL_ERROR_KEY @"SBBOriginalErrorKey"
 
+typedef NS_ENUM(NSInteger, SBBErrorCode)
+{
+    SBBErrorCodeUnknownError = -1,
+    SBBErrorCodeInternetNotConnected = -1000,
+    SBBErrorCodeServerNotReachable = -1001,
+    SBBErrorCodeServerUnderMaintenance = -1002,
+    SBBErrorCodeServerNotAuthenticated = -1003,
+    SBBErrorCodeServerPreconditionNotMet = -1004,
+    SBBErrorCodeNoCredentialsAvailable = -1005,
+    SBBErrorCodeUnsupportedAppVersion = -1006,
+    
+    SBBErrorCodeS3UploadErrorResponse = -1020,
+    
+    SBBErrorCodeNotAFileURL = -1100,
+    SBBErrorCodeObjectNotExpectedClass = -1101,
+    SBBErrorCodeTempFileError = -1102,
+    SBBErrorCodeTempFileReadError = -1103
+};
+
+/**
+ * This enum is deprecated. Use <SBBErrorCode> instead which is formatted for compliance with Swift 2.0 enums.
+ * @deprecated v3.0.6
+ */
+__attribute__((deprecated("use SBBErrorCode")))
 typedef NS_ENUM(NSInteger, SBBErrorCodes)
 {
     kSBBUnknownError = -1,
@@ -43,6 +67,7 @@ typedef NS_ENUM(NSInteger, SBBErrorCodes)
     kSBBServerNotAuthenticated = -1003,
     kSBBServerPreconditionNotMet = -1004,
     kSBBNoCredentialsAvailable = -1005,
+    kSBBUnsupportedAppVersion = -1006,
     
     kSBBS3UploadErrorResponse = -1020,
   
@@ -51,3 +76,5 @@ typedef NS_ENUM(NSInteger, SBBErrorCodes)
     kSBBTempFileError = -1102,
     kSBBTempFileReadError = -1103
 };
+
+

--- a/BridgeSDK/Networking/SBBNetworkManager.m
+++ b/BridgeSDK/Networking/SBBNetworkManager.m
@@ -514,7 +514,7 @@ NSString *kAPIPrefix = @"webservices";
     NSString *osName = [currentDevice systemName];
     NSString *osVersion = [currentDevice systemVersion];
     
-    return [NSString stringWithFormat:@"%@/%@ (%@; %@ %@) BridgeSDK/%0.0f", appName, appVersion, deviceModel, osName, osVersion, BridgeSDKVersionNumber];
+    return [NSString stringWithFormat:@"%@/%@ (%@; %@/%@) BridgeSDK/%0.0f", appName, appVersion, deviceModel, osName, osVersion, BridgeSDKVersionNumber];
 }
 
 - (NSString *)acceptLanguageHeader


### PR DESCRIPTION
Mapped the 410 (Gone) http status code returned by the server for app versions that are no longer supported to a BridgeSDK error code.  

Added NSLocalizedString macro to facilitate find-and-replace at some point in the future when error messages might need to be localized.

Deprecated SBBErrorCodes and replaced with SBBErrorCode which uses the enum format required for compatibility with Swift 2.0 enums. The use of the "k" prefix to mark a constant has gone out of vogue.

Handling the new 410 error code will be done in the mPower app (or possibly the AppCore). Will be implementing that in a future PR in that repository.