### PR TITLE
Localize BridgeSDK error messages

### DIFF
--- a/BridgeSDK/BridgeAPI/Categories/NSError+SBBAdditions.m
+++ b/BridgeSDK/BridgeAPI/Categories/NSError+SBBAdditions.m
@@ -29,6 +29,7 @@
  */
 
 #import "SBBErrors.h"
+#import "BridgeSDK.h"
 
 @implementation NSError (SBBAdditions)
 
@@ -40,20 +41,20 @@
     NSError * retError;
     if (!internetConnected) {
         retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeInternetNotConnected
-                                   userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Internet Not Connected",
+                                   userInfo:@{NSLocalizedDescriptionKey: NSLocalizedStringWithDefaultValue(@"SBB_ERROR_NO_INTERNET", @"BridgeSDK", [NSBundle bundleForClass:[BridgeSDK class]], @"Internet Not Connected",
                                                                                            @"Error Description: Internet not connected"),
                                               SBB_ORIGINAL_ERROR_KEY: urlError}];
     }
     else if (!isServerReachable) {
         retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeServerNotReachable
-                                   userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Backend Server Not Reachable",
+                                   userInfo:@{NSLocalizedDescriptionKey: NSLocalizedStringWithDefaultValue(@"SBB_ERROR_INTERNET_UNREACHABLE", @"BridgeSDK", [NSBundle bundleForClass:[BridgeSDK class]], @"Backend Server Not Reachable",
                                                                                            @"Error Description: Server not reachable"),
                                               SBB_ORIGINAL_ERROR_KEY: urlError}];
     }
     else
     {
         retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeUnknownError
-                                   userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Unknown Network Error",
+                                   userInfo:@{NSLocalizedDescriptionKey: NSLocalizedStringWithDefaultValue(@"SBB_ERROR_UNKNOWN_NETWORK_ERROR", @"BridgeSDK", [NSBundle bundleForClass:[BridgeSDK class]], @"Unknown Network Error",
                                                                                            @"Error Description: Unknown network error"),
                                               SBB_ORIGINAL_ERROR_KEY: urlError}];
     }
@@ -86,7 +87,7 @@
     }
     else if (statusCode == 410)
     {
-        NSString *localizedDescription = NSLocalizedString(@"Your version of this app is no longer supported. Please visit the app store to update your app.",
+        NSString *localizedDescription = NSLocalizedStringWithDefaultValue(@"SBB_ERROR_UNSUPPORTED_APP_VERSION", @"BridgeSDK", [NSBundle bundleForClass:[BridgeSDK class]], @"Your version of this app is no longer supported. Please visit the app store to update your app.",
                                                            @"Error Description: App requires upgrade");
         retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeUnsupportedAppVersion
                                    userInfo:@{NSLocalizedDescriptionKey: localizedDescription,
@@ -95,12 +96,12 @@
     else if (statusCode == 412)
     {
         retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeServerPreconditionNotMet
-                                   userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Client not consented",
-                                                                                           @"Error Description: Client not consented"),
+                                   userInfo:@{NSLocalizedDescriptionKey: NSLocalizedStringWithDefaultValue(@"SBB_ERROR_ACCOUNT_NOT_CONSENTED", @"BridgeSDK", [NSBundle bundleForClass:[BridgeSDK class]], @"Not consented",
+                                                                                           @"Error Description: Account holder has not consented to the study"),
                                               SBB_ORIGINAL_ERROR_KEY: foundationObject}];
     }
     else if (NSLocationInRange(statusCode, NSMakeRange(400, 99))) {
-        NSString *localizedFormat = NSLocalizedString(@"Client Error: %@. Please contact customer support.",
+        NSString *localizedFormat = NSLocalizedStringWithDefaultValue(@"SBB_ERROR_4XX_CONTACT_SUPPORT", @"BridgeSDK", [NSBundle bundleForClass:[BridgeSDK class]], @"Client Error: %@. Please contact customer support.",
                                                       @"Error Description: Unknown client app error");
         retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:statusCode
                                    userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:localizedFormat, @(statusCode)],
@@ -108,12 +109,12 @@
     }
     else if (statusCode == 503) {
         retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeServerUnderMaintenance
-                                   userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Backend Server Under Maintenance.",
+                                   userInfo:@{NSLocalizedDescriptionKey: NSLocalizedStringWithDefaultValue(@"SBB_ERROR_SERVER_MAINTENANCE", @"BridgeSDK", [NSBundle bundleForClass:[BridgeSDK class]], @"Backend Server Under Maintenance.",
                                                                                            @"Error Description: Backend Server Under Maintenance"),
                                               SBB_ORIGINAL_ERROR_KEY: foundationObject}];
     }
     else if (NSLocationInRange(statusCode, NSMakeRange(500, 99))) {
-        NSString *localizedFormat = NSLocalizedString(@"Backend Server Error: %@. Please contact customer support.",
+        NSString *localizedFormat = NSLocalizedStringWithDefaultValue(@"SBB_ERROR_SERVER_ERROR", @"BridgeSDK", [NSBundle bundleForClass:[BridgeSDK class]], @"Backend Server Error: %@. Please contact customer support.",
                                                       @"Error Description: Unknown server error");
         retError = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:statusCode
                                    userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:localizedFormat, @(statusCode)],
@@ -125,20 +126,20 @@
 + (NSError *)SBBNoCredentialsError
 {
   return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeNoCredentialsAvailable
-                         userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"No user login credentials available. Please sign in.",
+                         userInfo:@{NSLocalizedDescriptionKey: NSLocalizedStringWithDefaultValue(@"SBB_ERROR_NO_CREDENTIALS", @"BridgeSDK", [NSBundle bundleForClass:[BridgeSDK class]], @"No user login credentials available. Please sign in.",
                                                                                  @"Error Description: missing login credentials")}];
 }
 
 + (NSError *)SBBNotAuthenticatedError
 {
   return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeServerNotAuthenticated
-                         userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Server says: not authenticated. Please authenticate.",
+                         userInfo:@{NSLocalizedDescriptionKey: NSLocalizedStringWithDefaultValue(@"SBB_ERROR_NOT_AUTHENTICATED", @"BridgeSDK", [NSBundle bundleForClass:[BridgeSDK class]], @"Server says: not authenticated. Please authenticate.",
                                                                                  @"Error Description: not authenticated")}];
 }
 
 + (NSError *)generateSBBNotAFileURLErrorForURL:(NSURL *)url
 {
-  NSString *localizedFormat = NSLocalizedString(@"Not a valid file URL:\n%@", @"Error Description: not a valid url");
+  NSString *localizedFormat = NSLocalizedStringWithDefaultValue(@"SBB_ERROR_INVALID_FILE_URL", @"BridgeSDK", [NSBundle bundleForClass:[BridgeSDK class]], @"Not a valid file URL:\n%@", @"Error Description: not a valid url");
   NSString *desc = [NSString stringWithFormat:localizedFormat, url];
   return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeNotAFileURL
                          userInfo:@{NSLocalizedDescriptionKey: desc}];
@@ -146,21 +147,21 @@
 
 + (NSError *)generateSBBTempFileErrorForURL:(NSURL *)url
 {
-  NSString *localizedFormat = NSLocalizedString(@"Error copying file at URL to temp file:\n%@", @"Error Description: error copying file");
+  NSString *localizedFormat = NSLocalizedStringWithDefaultValue(@"SBB_ERROR_COPYING_FILE", @"BridgeSDK", [NSBundle bundleForClass:[BridgeSDK class]], @"Error copying file at URL to temp file:\n%@", @"Error Description: error copying file");
   NSString *desc = [NSString stringWithFormat:localizedFormat, url];
   return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeTempFileError userInfo:@{NSLocalizedDescriptionKey: desc}];
 }
 
 + (NSError *)generateSBBTempFileReadErrorForURL:(NSURL *)url
 {
-  NSString *localizedFormat = NSLocalizedString(@"Error reading temp file for original file URL:\n%@", @"Error Description: error reading temp file");
+  NSString *localizedFormat = NSLocalizedStringWithDefaultValue(@"SBB_ERROR_READING_TEMP_FILE", @"BridgeSDK", [NSBundle bundleForClass:[BridgeSDK class]], @"Error reading temp file for original file URL:\n%@", @"Error Description: error reading temp file");
   NSString *desc = [NSString stringWithFormat:localizedFormat, url];
   return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeTempFileError userInfo:@{NSLocalizedDescriptionKey: desc}];
 }
 
 + (NSError *)generateSBBObjectNotExpectedClassErrorForObject:(id)object expectedClass:(Class)expectedClass
 {
-  NSString *localizedFormat = NSLocalizedString(@"Object '%1$@' is of class %2$@, expected class %3$@",
+  NSString *localizedFormat = NSLocalizedStringWithDefaultValue(@"SBB_ERROR_UNEXPECTED_CLASS", @"BridgeSDK", [NSBundle bundleForClass:[BridgeSDK class]], @"Object '%1$@' is of class %2$@, expected class %3$@",
                                                 @"Error Description: Object is not of expected class. object description=$1, actual class=$2, expected class=$3");
   NSString *desc = [NSString stringWithFormat:localizedFormat, object, NSStringFromClass([object class]), NSStringFromClass(expectedClass)];
   return [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeObjectNotExpectedClass userInfo:@{NSLocalizedDescriptionKey: desc}];


### PR DESCRIPTION
...into our own .strings file with its own name so someday when we support BridgeSDK being a CocoaPod it won't conflict with the app's Localizable.strings file when its gets pulled into the main bundle, which apparently is a thing that happens, according to a commit comment I saw on ResearchKit...