### PR TITLE
Prevent crashes when accessing SBBUploadManager from multiple threads

### DIFF
--- a/BridgeSDK/BridgeAPI/SBBUploadManager.m
+++ b/BridgeSDK/BridgeAPI/SBBUploadManager.m
@@ -181,8 +181,10 @@ static NSString *kUploadSessionsKey = @"SBBUploadSessionsKey";
 
 - (SBBUploadManagerCompletionBlock)completionBlockForFile:(NSString *)file
 {
-    SBBUploadCompletionWrapper *wrapper = [_uploadCompletionHandlers objectForKey:file];
-    return wrapper.completion;
+    @synchronized(self) {
+        SBBUploadCompletionWrapper *wrapper = [_uploadCompletionHandlers objectForKey:file];
+        return wrapper.completion;
+    }
 }
 
 - (void)setCompletionBlock:(SBBUploadManagerCompletionBlock)completion forFile:(NSString *)file
@@ -192,12 +194,16 @@ static NSString *kUploadSessionsKey = @"SBBUploadSessionsKey";
         return;
     }
     SBBUploadCompletionWrapper *wrapper = [[SBBUploadCompletionWrapper alloc] initWithBlock:completion];
-    [_uploadCompletionHandlers setObject:wrapper forKey:file];
+    @synchronized(self) {
+        [_uploadCompletionHandlers setObject:wrapper forKey:file];
+    }
 }
 
 - (void)removeCompletionBlockForFile:(NSString *)file
 {
-    [_uploadCompletionHandlers removeObjectForKey:file];
+    @synchronized(self) {
+        [_uploadCompletionHandlers removeObjectForKey:file];
+    }
 }
 
 - (void)setUploadRequestJSON:(id)json forFile:(NSString *)fileURLString
@@ -339,7 +345,9 @@ static NSString *kUploadSessionsKey = @"SBBUploadSessionsKey";
     }
     
     // clear everything out
-    [_uploadCompletionHandlers removeAllObjects];
+    @synchronized(self) {
+        [_uploadCompletionHandlers removeAllObjects];
+    }
     [defaults removeObjectForKey:kUploadRequestsKey];
     [defaults removeObjectForKey:kUploadSessionsKey];
     [defaults removeObjectForKey:kUploadFilesKey];


### PR DESCRIPTION
Hi, I'm currently using `Bridge-iOS-SDK` in my project and I found that the application that I'm working on crashes when `SBBUploadManager` instance is accessed from multiple threads at the same time. 

Please consider the following solution as it should prevent from crashes and make the `SBBUploadManager` class thread-safe.

**Changelog**:

- add `@synchronized` block when accessing `uploadCompletionHandlers` dictionary