### PR TITLE
Only release the reachability object if for some reason alloc init returns nil

### DIFF
--- a/BridgeSDK/Networking/Reachability.m
+++ b/BridgeSDK/Networking/Reachability.m
@@ -115,7 +115,10 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReach
 			returnValue->_reachabilityRef = reachability;
 			returnValue->_alwaysReturnLocalWiFiStatus = NO;
 		}
-        CFRelease(reachability);
+        else
+        {
+            CFRelease(reachability);
+        }
 	}
     
 	return returnValue;
@@ -136,7 +139,10 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReach
 			returnValue->_reachabilityRef = reachability;
 			returnValue->_alwaysReturnLocalWiFiStatus = NO;
 		}
-        CFRelease(reachability);
+        else
+        {
+            CFRelease(reachability);
+        }
 	}
     
 	return returnValue;


### PR DESCRIPTION
Oops.