### PR TITLE
fix for : [__NSCFDictionary removeObjectForKey:]: attempt to remove nil key

### DIFF
--- a/BridgeSDK/BridgeAPI/SBBUploadManager.m
+++ b/BridgeSDK/BridgeAPI/SBBUploadManager.m
@@ -202,6 +202,11 @@ static NSString *kUploadSessionsKey = @"SBBUploadSessionsKey";
 
 - (void)setUploadRequestJSON:(id)json forFile:(NSString *)fileURLString
 {
+    if (!fileURLString) {
+        NSLog(@"Aborting setting json on nil fileURLString");
+        return;
+    }
+    
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     
     NSMutableDictionary *uploadRequests = [[defaults dictionaryForKey:kUploadRequestsKey] mutableCopy];


### PR DESCRIPTION
i am trying to prevent some of the crashes in our production app caused by nil fileURLString, i was hoping you might help identifying cases in which fileURLString might be nil. 
Here is the stacktrace for the crash:

Thread : Fatal Exception: NSInvalidArgumentException
0  CoreFoundation                 0x182022e38 __exceptionPreprocess
1  libobjc.A.dylib                0x181687f80 objc_exception_throw
2  CoreFoundation                 0x182022d80 -[NSException initWithCoder:]
3  CoreFoundation                 0x181f46840 -[__NSCFDictionary removeObjectForKey:]
4  BridgeSDK                      0x10132c588 -[SBBUploadManager setUploadRequestJSON:forFile:] (SBBUploadManager.m:206)
5  BridgeSDK                      0x10132d1a8 -[SBBUploadManager completeUploadOfFile:withError:] (SBBUploadManager.m:320)
6  BridgeSDK                      0x10132d810 -[SBBUploadManager URLSession:downloadTask:didFinishDownloadingToURL:] (SBBUploadManager.m:371)
7  BridgeSDK                      0x10133896c -[SBBNetworkManager URLSession:downloadTask:didFinishDownloadingToURL:] (SBBNetworkManager.m:588)
8  CFNetwork                      0x182731bac __82-[NSURLSession delegate_downloadTask:didFinishDownloadingToURL:completionHandler:]_block_invoke
9  Foundation                     0x1829dc510 __NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__
10 Foundation                     0x18292e900 -[NSBlockOperation main]
11 Foundation                     0x18291eed8 -[__NSOperationInternal _start:]
12 Foundation                     0x1829de904 __NSOQSchedule_f
13 libdispatch.dylib              0x181a6d47c _dispatch_client_callout
14 libdispatch.dylib              0x181a794c0 _dispatch_queue_drain
15 libdispatch.dylib              0x181a70f80 _dispatch_queue_invoke
16 libdispatch.dylib              0x181a7b390 _dispatch_root_queue_drain