### PR TITLE
updating SBBUploadManager:setUploadRequestJSON:forFile to use delegateQueue

### DIFF
--- a/BridgeSDK/BridgeAPI/SBBUploadManager.m
+++ b/BridgeSDK/BridgeAPI/SBBUploadManager.m
@@ -307,7 +307,9 @@ static NSString *kUploadSessionsKey = @"SBBUploadSessionsKey";
     uploadRequest.contentMd5 = [fileData contentMD5];
     // don't use the shared SBBObjectManager--we want to use only SDK default objects for types
     NSDictionary *uploadRequestJSON = [_cleanObjectManager bridgeJSONFromObject:uploadRequest];
-    [self setUploadRequestJSON:uploadRequestJSON forFile:[tempFileURL path]];
+    [((SBBNetworkManager *)self.networkManager).backgroundSession.delegateQueue addOperationWithBlock:^{
+        [self setUploadRequestJSON:uploadRequestJSON forFile:[tempFileURL path]];
+    }];
     NSMutableDictionary *headers = [NSMutableDictionary dictionary];
     [self.authManager addAuthHeaderToHeaders:headers];
     [self.networkManager downloadFileFromURLString:kSBBUploadAPI method:@"POST" httpHeaders:headers parameters:uploadRequestJSON taskDescription:[tempFileURL path] downloadCompletion:nil taskCompletion:nil];

--- a/BridgeSDK/BridgeAPI/SBBUploadManager.m
+++ b/BridgeSDK/BridgeAPI/SBBUploadManager.m
@@ -204,23 +204,19 @@ static NSString *kUploadSessionsKey = @"SBBUploadSessionsKey";
 
 - (void)setUploadRequestJSON:(id)json forFile:(NSString *)fileURLString
 {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     
-    [((SBBNetworkManager *)self.networkManager).backgroundSession.delegateQueue addOperationWithBlock:^{
-        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-        
-        NSMutableDictionary *uploadRequests = [[defaults dictionaryForKey:kUploadRequestsKey] mutableCopy];
-        if (!uploadRequests) {
-            uploadRequests = [NSMutableDictionary dictionary];
-        }
-        if (json) {
-            [uploadRequests setObject:json forKey:fileURLString];
-        } else {
-            [uploadRequests removeObjectForKey:fileURLString];
-        }
-        [defaults setObject:uploadRequests forKey:kUploadRequestsKey];
-        [defaults synchronize];
-        
-    }];
+    NSMutableDictionary *uploadRequests = [[defaults dictionaryForKey:kUploadRequestsKey] mutableCopy];
+    if (!uploadRequests) {
+        uploadRequests = [NSMutableDictionary dictionary];
+    }
+    if (json) {
+        [uploadRequests setObject:json forKey:fileURLString];
+    } else {
+        [uploadRequests removeObjectForKey:fileURLString];
+    }
+    [defaults setObject:uploadRequests forKey:kUploadRequestsKey];
+    [defaults synchronize];
 }
 
 - (SBBUploadRequest *)uploadRequestForFile:(NSString *)fileURLString

--- a/BridgeSDK/BridgeAPI/SBBUploadManager.m
+++ b/BridgeSDK/BridgeAPI/SBBUploadManager.m
@@ -204,19 +204,23 @@ static NSString *kUploadSessionsKey = @"SBBUploadSessionsKey";
 
 - (void)setUploadRequestJSON:(id)json forFile:(NSString *)fileURLString
 {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     
-    NSMutableDictionary *uploadRequests = [[defaults dictionaryForKey:kUploadRequestsKey] mutableCopy];
-    if (!uploadRequests) {
-        uploadRequests = [NSMutableDictionary dictionary];
-    }
-    if (json) {
-        [uploadRequests setObject:json forKey:fileURLString];
-    } else {
-        [uploadRequests removeObjectForKey:fileURLString];
-    }
-    [defaults setObject:uploadRequests forKey:kUploadRequestsKey];
-    [defaults synchronize];
+    [((SBBNetworkManager *)self.networkManager).backgroundSession.delegateQueue addOperationWithBlock:^{
+        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+        
+        NSMutableDictionary *uploadRequests = [[defaults dictionaryForKey:kUploadRequestsKey] mutableCopy];
+        if (!uploadRequests) {
+            uploadRequests = [NSMutableDictionary dictionary];
+        }
+        if (json) {
+            [uploadRequests setObject:json forKey:fileURLString];
+        } else {
+            [uploadRequests removeObjectForKey:fileURLString];
+        }
+        [defaults setObject:uploadRequests forKey:kUploadRequestsKey];
+        [defaults synchronize];
+        
+    }];
 }
 
 - (SBBUploadRequest *)uploadRequestForFile:(NSString *)fileURLString


### PR DESCRIPTION
updating SBBUploadManager:setUploadRequestJSON:forFile to use backgroundSession.delegateQueue as concurrent executions cause dirty reads which further cause:  "Error retrieving upload request headers for temp file URL ", and eventually uploads fail