### PR TITLE
FPHS 561

### DIFF
--- a/BridgeSDK/BridgeAPI/SBBAuthManager.m
+++ b/BridgeSDK/BridgeAPI/SBBAuthManager.m
@@ -277,11 +277,13 @@ void dispatchSyncToKeychainQueue(dispatch_block_t dispatchBlock)
 
 - (NSURLSessionDataTask *)signUpWithEmail:(NSString *)email username:(NSString *)username password:(NSString *)password dataGroups:(NSArray<NSString *> *)dataGroups completion:(SBBNetworkManagerCompletionBlock)completion
 {
+    // Add a no-cache header to prevent the caching of sensitive data like the password
+    NSDictionary *headers = [[NSDictionary alloc] initWithObjectsAndKeys:@"no-cache", @"cache-control", nil];
     NSMutableDictionary *params = [@{@"study":gSBBAppStudy, @"email":email, @"username":username, @"password":password, @"type":@"SignUp"} mutableCopy];
     if (dataGroups) {
         [params setObject:dataGroups forKey:@"dataGroups"];
     }
-    return [_networkManager post:kSBBAuthSignUpAPI headers:nil parameters:params completion:completion];
+    return [_networkManager post:kSBBAuthSignUpAPI headers:headers parameters:params completion:completion];
 }
 
 - (NSURLSessionDataTask *)signUpWithEmail:(NSString *)email username:(NSString *)username password:(NSString *)password completion:(SBBNetworkManagerCompletionBlock)completion
@@ -301,7 +303,9 @@ void dispatchSyncToKeychainQueue(dispatch_block_t dispatchBlock)
 
 - (NSURLSessionDataTask *)signInWithEmail:(NSString *)email password:(NSString *)password completion:(SBBNetworkManagerCompletionBlock)completion
 {
-    return [_networkManager post:kSBBAuthSignInAPI headers:nil parameters:@{@"study":gSBBAppStudy, @"email":email, @"password":password, @"type":@"SignIn"} completion:^(NSURLSessionDataTask *task, id responseObject, NSError *error) {
+    // Add a no-cache header to prevent the caching of sensitive data like the password
+    NSDictionary *headers = [[NSDictionary alloc] initWithObjectsAndKeys:@"no-cache", @"cache-control", nil];
+    return [_networkManager post:kSBBAuthSignInAPI headers:headers parameters:@{@"study":gSBBAppStudy, @"email":email, @"password":password, @"type":@"SignIn"} completion:^(NSURLSessionDataTask *task, id responseObject, NSError *error) {
         // Save session token in the keychain
         // ??? Save credentials in the keychain?
         NSString *sessionToken = responseObject[@"sessionToken"];

--- a/BridgeSDK/BridgeAPI/SBBAuthManager.m
+++ b/BridgeSDK/BridgeAPI/SBBAuthManager.m
@@ -277,13 +277,11 @@ void dispatchSyncToKeychainQueue(dispatch_block_t dispatchBlock)
 
 - (NSURLSessionDataTask *)signUpWithEmail:(NSString *)email username:(NSString *)username password:(NSString *)password dataGroups:(NSArray<NSString *> *)dataGroups completion:(SBBNetworkManagerCompletionBlock)completion
 {
-    // Add a no-cache header to prevent the caching of sensitive data like the password
-    NSDictionary *nocacheHeader = [[NSDictionary alloc] initWithObjectsAndKeys:@"no-cache", @"cache-control", nil];
     NSMutableDictionary *params = [@{@"study":gSBBAppStudy, @"email":email, @"username":username, @"password":password, @"type":@"SignUp"} mutableCopy];
     if (dataGroups) {
         [params setObject:dataGroups forKey:@"dataGroups"];
     }
-    return [_networkManager post:kSBBAuthSignUpAPI headers:nocacheHeader parameters:params completion:completion];
+    return [_networkManager post:kSBBAuthSignUpAPI headers:nil parameters:params completion:completion];
 }
 
 - (NSURLSessionDataTask *)signUpWithEmail:(NSString *)email username:(NSString *)username password:(NSString *)password completion:(SBBNetworkManagerCompletionBlock)completion
@@ -303,9 +301,7 @@ void dispatchSyncToKeychainQueue(dispatch_block_t dispatchBlock)
 
 - (NSURLSessionDataTask *)signInWithEmail:(NSString *)email password:(NSString *)password completion:(SBBNetworkManagerCompletionBlock)completion
 {
-    // Add a no-cache header to prevent the caching of sensitive data like the password
-    NSDictionary *nocacheHeader = [[NSDictionary alloc] initWithObjectsAndKeys:@"no-cache", @"cache-control", nil];
-    return [_networkManager post:kSBBAuthSignInAPI headers:nocacheHeader parameters:@{@"study":gSBBAppStudy, @"email":email, @"password":password, @"type":@"SignIn"} completion:^(NSURLSessionDataTask *task, id responseObject, NSError *error) {
+    return [_networkManager post:kSBBAuthSignInAPI headers:nil parameters:@{@"study":gSBBAppStudy, @"email":email, @"password":password, @"type":@"SignIn"} completion:^(NSURLSessionDataTask *task, id responseObject, NSError *error) {
         // Save session token in the keychain
         // ??? Save credentials in the keychain?
         NSString *sessionToken = responseObject[@"sessionToken"];
@@ -437,9 +433,7 @@ void dispatchSyncToKeychainQueue(dispatch_block_t dispatchBlock)
 
 - (NSURLSessionDataTask *)resetPasswordToNewPassword:(NSString *)password resetToken:(NSString *)token completion:(SBBNetworkManagerCompletionBlock)completion
 {
-    // Add a no-cache header to prevent the caching of sensitive data like the password
-    NSDictionary *nocacheHeader = [[NSDictionary alloc] initWithObjectsAndKeys:@"no-cache", @"cache-control", nil];
-    return [_networkManager post:kSBBAuthResetAPI headers:nocacheHeader parameters:@{@"password":password, @"sptoken":token, @"type":@"PasswordReset"} completion:completion];
+    return [_networkManager post:kSBBAuthResetAPI headers:nil parameters:@{@"password":password, @"sptoken":token, @"type":@"PasswordReset"} completion:completion];
 }
 
 #pragma mark Internal helper methods

--- a/BridgeSDK/BridgeAPI/SBBAuthManager.m
+++ b/BridgeSDK/BridgeAPI/SBBAuthManager.m
@@ -278,12 +278,12 @@ void dispatchSyncToKeychainQueue(dispatch_block_t dispatchBlock)
 - (NSURLSessionDataTask *)signUpWithEmail:(NSString *)email username:(NSString *)username password:(NSString *)password dataGroups:(NSArray<NSString *> *)dataGroups completion:(SBBNetworkManagerCompletionBlock)completion
 {
     // Add a no-cache header to prevent the caching of sensitive data like the password
-    NSDictionary *headers = [[NSDictionary alloc] initWithObjectsAndKeys:@"no-cache", @"cache-control", nil];
+    NSDictionary *nocacheHeader = [[NSDictionary alloc] initWithObjectsAndKeys:@"no-cache", @"cache-control", nil];
     NSMutableDictionary *params = [@{@"study":gSBBAppStudy, @"email":email, @"username":username, @"password":password, @"type":@"SignUp"} mutableCopy];
     if (dataGroups) {
         [params setObject:dataGroups forKey:@"dataGroups"];
     }
-    return [_networkManager post:kSBBAuthSignUpAPI headers:headers parameters:params completion:completion];
+    return [_networkManager post:kSBBAuthSignUpAPI headers:nocacheHeader parameters:params completion:completion];
 }
 
 - (NSURLSessionDataTask *)signUpWithEmail:(NSString *)email username:(NSString *)username password:(NSString *)password completion:(SBBNetworkManagerCompletionBlock)completion
@@ -304,8 +304,8 @@ void dispatchSyncToKeychainQueue(dispatch_block_t dispatchBlock)
 - (NSURLSessionDataTask *)signInWithEmail:(NSString *)email password:(NSString *)password completion:(SBBNetworkManagerCompletionBlock)completion
 {
     // Add a no-cache header to prevent the caching of sensitive data like the password
-    NSDictionary *headers = [[NSDictionary alloc] initWithObjectsAndKeys:@"no-cache", @"cache-control", nil];
-    return [_networkManager post:kSBBAuthSignInAPI headers:headers parameters:@{@"study":gSBBAppStudy, @"email":email, @"password":password, @"type":@"SignIn"} completion:^(NSURLSessionDataTask *task, id responseObject, NSError *error) {
+    NSDictionary *nocacheHeader = [[NSDictionary alloc] initWithObjectsAndKeys:@"no-cache", @"cache-control", nil];
+    return [_networkManager post:kSBBAuthSignInAPI headers:nocacheHeader parameters:@{@"study":gSBBAppStudy, @"email":email, @"password":password, @"type":@"SignIn"} completion:^(NSURLSessionDataTask *task, id responseObject, NSError *error) {
         // Save session token in the keychain
         // ??? Save credentials in the keychain?
         NSString *sessionToken = responseObject[@"sessionToken"];

--- a/BridgeSDK/BridgeAPI/SBBAuthManager.m
+++ b/BridgeSDK/BridgeAPI/SBBAuthManager.m
@@ -437,7 +437,9 @@ void dispatchSyncToKeychainQueue(dispatch_block_t dispatchBlock)
 
 - (NSURLSessionDataTask *)resetPasswordToNewPassword:(NSString *)password resetToken:(NSString *)token completion:(SBBNetworkManagerCompletionBlock)completion
 {
-    return [_networkManager post:kSBBAuthResetAPI headers:nil parameters:@{@"password":password, @"sptoken":token, @"type":@"PasswordReset"} completion:completion];
+    // Add a no-cache header to prevent the caching of sensitive data like the password
+    NSDictionary *nocacheHeader = [[NSDictionary alloc] initWithObjectsAndKeys:@"no-cache", @"cache-control", nil];
+    return [_networkManager post:kSBBAuthResetAPI headers:nocacheHeader parameters:@{@"password":password, @"sptoken":token, @"type":@"PasswordReset"} completion:completion];
 }
 
 #pragma mark Internal helper methods

--- a/BridgeSDK/Networking/SBBNetworkManager.m
+++ b/BridgeSDK/Networking/SBBNetworkManager.m
@@ -557,7 +557,7 @@ NSString *kAPIPrefix = @"webservices";
   mutableRequest.HTTPShouldHandleCookies = self.sendCookies;
   [mutableRequest setValue:[self userAgentHeader] forHTTPHeaderField:@"User-Agent"];
   [mutableRequest setValue:[self acceptLanguageHeader] forHTTPHeaderField:@"Accept-Language"];
-  // Add a no-cache header to prevent data from being caching the request locally
+  // Add a no-cache header to prevent data from being cached locally
   [mutableRequest setValue:@"no-cache" forHTTPHeaderField:@"cache-control"];
   
   if (headers) {

--- a/BridgeSDK/Networking/SBBNetworkManager.m
+++ b/BridgeSDK/Networking/SBBNetworkManager.m
@@ -557,6 +557,8 @@ NSString *kAPIPrefix = @"webservices";
   mutableRequest.HTTPShouldHandleCookies = self.sendCookies;
   [mutableRequest setValue:[self userAgentHeader] forHTTPHeaderField:@"User-Agent"];
   [mutableRequest setValue:[self acceptLanguageHeader] forHTTPHeaderField:@"Accept-Language"];
+  // Add a no-cache header to prevent data from being caching the request locally
+  [mutableRequest setValue:@"no-cache" forHTTPHeaderField:@"cache-control"];
   
   if (headers) {
     for (NSString *header in headers.allKeys) {


### PR DESCRIPTION
Prevent caching of signup/signin POST requests that include the password.

Basically, iOS really likes to cache things that use NSURLRequest. While Bridge server is careful to not return the password in any responses, iOS will still cache POSTs that we make to the server. The POST requests that appear to have relevant info (password especially) are SignIn and SignUp. To prevent these POSTs from being cached, we need to add a cache-control header to the request.

There are a few different approaches, but this seemed to be the simplest and best and appeared to work after multiple before and after tests.

The only other call that appeared to have a risk of having this same issue was resetPasswordToNewPassword so the change was applied there as well although I haven't done before/after tests. 

Repro steps to access cached password before this change is applied:

Launch app
sign in
make it to main screen
download the cache.db-wal file and open it in xcode, then search for your password