### PR TITLE
Bridge 1390

### DIFF
--- a/BridgeSDK/BridgeAPI/SBBUploadManager.m
+++ b/BridgeSDK/BridgeAPI/SBBUploadManager.m
@@ -216,10 +216,15 @@ static NSString *kUploadSessionsKey = @"SBBUploadSessionsKey";
     [defaults synchronize];
 }
 
+- (NSDictionary *)uploadRequestJSONForFile:(NSString *)fileURLString
+{
+    return [[NSUserDefaults standardUserDefaults] dictionaryForKey:kUploadRequestsKey][fileURLString];
+}
+
 - (SBBUploadRequest *)uploadRequestForFile:(NSString *)fileURLString
 {
     SBBUploadRequest *uploadRequest = nil;
-    id json = [[NSUserDefaults standardUserDefaults] dictionaryForKey:kUploadRequestsKey][fileURLString];
+    id json = [self uploadRequestJSONForFile:fileURLString];
     if (json) {
         uploadRequest = [_cleanObjectManager objectFromBridgeJSON:json];
     }
@@ -286,26 +291,36 @@ static NSString *kUploadSessionsKey = @"SBBUploadSessionsKey";
 - (void)uploadedFileToS3WithTask:(NSURLSessionUploadTask *)uploadTask response:(NSHTTPURLResponse *)httpResponse error:(NSError *)error
 {
     NSInteger httpStatusCode = httpResponse.statusCode;
+    NSString *filePath = uploadTask.taskDescription;
     
     // client-side networking issue
     if (error) {
-        [self completeUploadOfFile:uploadTask.taskDescription withError:error];
+        [self completeUploadOfFile:filePath withError:error];
         return;
     }
     
     // server didn't like the request, or otherwise hiccupped
-    if (httpStatusCode >= 300) {
+    if (httpStatusCode == 403) {
+        // this will have happened because the pre-signed url timed out before starting the actual upload to S3,
+        // so try, try again
+#if DEBUG
+        NSLog(@"Background file upload to S3 failed with HTTP status 403 (presumably due to presigned url timeout); retrying...");
+#endif
+        NSDictionary *uploadRequestJSON = [self uploadRequestJSONForFile:filePath];
+        [self kickOffUploadForFile:filePath uploadRequestJSON:uploadRequestJSON];
+        return;
+    } else if (httpStatusCode >= 300) {
         // iOS handles redirects automatically so only e.g. 307 resource not changed etc. from the 300 range should end up here
         // (along with all 4xx and 5xx of course)
         NSString *description = [NSString stringWithFormat:@"Background file upload to S3 failed with HTTP status %ld", (long)httpStatusCode];
         NSError *s3Error = [NSError errorWithDomain:SBB_ERROR_DOMAIN code:SBBErrorCodeS3UploadErrorResponse userInfo:@{NSLocalizedDescriptionKey: description}];
-        [self completeUploadOfFile:uploadTask.taskDescription withError:s3Error];
+        [self completeUploadOfFile:filePath withError:s3Error];
         return;
     }
     
     // tell the API we done did it
-    SBBUploadSession *uploadSession = [self uploadSessionForFile:uploadTask.taskDescription];
-    [self setUploadSessionJSON:nil forFile:uploadTask.taskDescription];
+    SBBUploadSession *uploadSession = [self uploadSessionForFile:filePath];
+    [self setUploadSessionJSON:nil forFile:filePath];
     NSString *uploadId = uploadSession.id;
     if (!uploadId.length) {
         NSAssert(uploadId, @"uploadId is nil");
@@ -360,7 +375,7 @@ static NSString *kUploadSessionsKey = @"SBBUploadSessionsKey";
         NSURL *fileUrl = [NSURL fileURLWithPath:downloadTask.taskDescription];
         [self.networkManager uploadFile:fileUrl httpHeaders:uploadHeaders toUrl:uploadSession.url taskDescription:downloadTask.taskDescription completion:^(NSURLSessionTask *task, NSHTTPURLResponse *response, NSError *error) {
 #if DEBUG
-            if (error) {
+            if (error || response.statusCode >= 300) {
                 NSLog(@"Error uploading to S3 for upload ID %@:\n%@", uploadSession.id, error);
             } else {
                 NSLog(@"Successfully uploaded to S3 for upload ID %@", uploadSession.id);
@@ -421,15 +436,24 @@ static NSString *kUploadSessionsKey = @"SBBUploadSessionsKey";
     uploadRequest.contentLengthValue = fileData.length;
     uploadRequest.contentType = contentType;
     uploadRequest.contentMd5 = [fileData contentMD5];
+    NSString *filePath = [tempFileURL path];
     // don't use the shared SBBObjectManager--we want to use only SDK default objects for types
     NSDictionary *uploadRequestJSON = [_cleanObjectManager bridgeJSONFromObject:uploadRequest];
+    [self kickOffUploadForFile:filePath uploadRequestJSON:uploadRequestJSON];
+}
+
+// This presumes uploadFileToBridge:contentType:completion: was called to set things up for this file,
+// so can be used for both the initial upload attempt and any retries due to 403 (presigned url timed out).
+- (void)kickOffUploadForFile:(NSString *)filePath uploadRequestJSON:(NSDictionary *)uploadRequestJSON
+{
+    // this starts the process by downloading the Bridge UploadSession.
     [((SBBNetworkManager *)self.networkManager).backgroundSession.delegateQueue addOperationWithBlock:^{
-        [self setUploadRequestJSON:uploadRequestJSON forFile:[tempFileURL path]];
+        [self setUploadRequestJSON:uploadRequestJSON forFile:filePath];
     }];
     NSMutableDictionary *headers = [NSMutableDictionary dictionary];
     [self.authManager addAuthHeaderToHeaders:headers];
     
-    __block NSURLSessionDownloadTask *downloadTask = [self.networkManager downloadFileFromURLString:kSBBUploadAPI method:@"POST" httpHeaders:headers parameters:uploadRequestJSON taskDescription:[tempFileURL path] downloadCompletion:^(NSURL *file) {
+    __block NSURLSessionDownloadTask *downloadTask = [self.networkManager downloadFileFromURLString:kSBBUploadAPI method:@"POST" httpHeaders:headers parameters:uploadRequestJSON taskDescription:filePath downloadCompletion:^(NSURL *file) {
         [self downloadedBridgeUploadSessionWithDownloadTask:downloadTask fileURL:file];
     } taskCompletion:^(NSURLSessionTask *task, NSHTTPURLResponse *response, NSError *error) {
         // We don't care about this unless there was a network error, or an HTTP response indicating an error.

--- a/BridgeSDK/Networking/SBBNetworkManager.m
+++ b/BridgeSDK/Networking/SBBNetworkManager.m
@@ -727,7 +727,8 @@ NSString *kAPIPrefix = @"webservices";
         NSData *resumeData = error.userInfo[NSURLSessionDownloadTaskResumeData];
         if (resumeData) {
             // there's resume data from a download task, so retry
-            [session downloadTaskWithResumeData:resumeData];
+            NSURLSessionDownloadTask *resumeTask = [session downloadTaskWithResumeData:resumeData];
+            [resumeTask resume];
             return;
         }
     }

--- a/BridgeSDK/Networking/SBBNetworkManager.m
+++ b/BridgeSDK/Networking/SBBNetworkManager.m
@@ -726,8 +726,19 @@ NSString *kAPIPrefix = @"webservices";
     if (error) {
         NSData *resumeData = error.userInfo[NSURLSessionDownloadTaskResumeData];
         if (resumeData) {
-            // there's resume data from a download task, so retry
+            // there's resume data from a download task, so we'll use it to retry
             NSURLSessionDownloadTask *resumeTask = [session downloadTaskWithResumeData:resumeData];
+            NSURLSessionDownloadTask *dlTask = (NSURLSessionDownloadTask *)task;
+
+            // transfer the information associated with the old task to the new one
+            resumeTask.taskDescription = task.taskDescription;
+            SBBNetworkManagerTaskCompletionBlock taskCompletion = [self completionBlockForTask:dlTask];
+            SBBNetworkManagerDownloadCompletionBlock downloadCompletion = [self completionBlockForDownload:dlTask];
+            [self setCompletionBlock:taskCompletion forTask:resumeTask];
+            [self setCompletionBlock:downloadCompletion forDownload:resumeTask];
+            [self removeCompletionBlockForTask:dlTask];
+            [self removeCompletionBlockForDownload:dlTask];
+            
             [resumeTask resume];
             return;
         }

--- a/BridgeSDK/Networking/SBBNetworkManager.m
+++ b/BridgeSDK/Networking/SBBNetworkManager.m
@@ -723,6 +723,14 @@ NSString *kAPIPrefix = @"webservices";
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
 {
+    if (error) {
+        NSData *resumeData = error.userInfo[NSURLSessionDownloadTaskResumeData];
+        if (resumeData) {
+            // there's resume data from a download task, so retry
+            [session downloadTaskWithResumeData:resumeData];
+            return;
+        }
+    }
     SBBNetworkManagerTaskCompletionBlock completion = [self completionBlockForTask:task];
     if (completion) {
         completion((NSURLSessionUploadTask *)task, (NSHTTPURLResponse *)task.response, error);

--- a/BridgeSDK/Networking/SBBNetworkManager.m
+++ b/BridgeSDK/Networking/SBBNetworkManager.m
@@ -367,7 +367,11 @@ NSString *kAPIPrefix = @"webservices";
     [request setAllHTTPHeaderFields:headers];
     request.HTTPMethod = @"PUT";
     NSURLSessionUploadTask *task = [self.backgroundSession uploadTaskWithRequest:request fromFile:fileUrl];
-    [self setCompletionBlock:completion forTask:task];
+    
+    [self.backgroundSession.delegateQueue addOperationWithBlock:^{
+        [self setCompletionBlock:completion forTask:task];
+    }];
+
     task.taskDescription = description;
     
     [task resume];
@@ -447,8 +451,12 @@ NSString *kAPIPrefix = @"webservices";
     };
     
     NSURLSessionDownloadTask *task = [self.backgroundSession downloadTaskWithRequest:request];
-    [self setCompletionBlock:downloadCompletionWithErrorChecking forDownload:task];
-    [self setCompletionBlock:taskCompletionWithErrorChecking forTask:task];
+    
+    [self.backgroundSession.delegateQueue addOperationWithBlock:^{
+        [self setCompletionBlock:downloadCompletionWithErrorChecking forDownload:task];
+        [self setCompletionBlock:taskCompletionWithErrorChecking forTask:task];
+    }];
+    
     task.taskDescription = description;
     
     [task resume];
@@ -721,28 +729,35 @@ NSString *kAPIPrefix = @"webservices";
 
 #pragma mark - NSURLSessionTaskDelegate methods
 
+// this method assumes it always gets called from within the background session's delegate queue
+- (void)retryFailedDownload:(NSURLSessionDownloadTask *)task forSession:(NSURLSession *)session withResumeData:(NSData *)resumeData
+{
+    NSURLSessionDownloadTask *resumeTask = [session downloadTaskWithResumeData:resumeData];
+    
+    // transfer the information associated with the old task to the new one
+    resumeTask.taskDescription = task.taskDescription;
+    SBBNetworkManagerTaskCompletionBlock taskCompletion = [self completionBlockForTask:task];
+    SBBNetworkManagerDownloadCompletionBlock downloadCompletion = [self completionBlockForDownload:task];
+    [self setCompletionBlock:taskCompletion forTask:resumeTask];
+    [self setCompletionBlock:downloadCompletion forDownload:resumeTask];
+    [self removeCompletionBlockForTask:task];
+    [self removeCompletionBlockForDownload:task];
+    
+    [resumeTask resume];
+}
+
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
 {
     if (error) {
         NSData *resumeData = error.userInfo[NSURLSessionDownloadTaskResumeData];
         if (resumeData) {
             // there's resume data from a download task, so we'll use it to retry
-            NSURLSessionDownloadTask *resumeTask = [session downloadTaskWithResumeData:resumeData];
-            NSURLSessionDownloadTask *dlTask = (NSURLSessionDownloadTask *)task;
-
-            // transfer the information associated with the old task to the new one
-            resumeTask.taskDescription = task.taskDescription;
-            SBBNetworkManagerTaskCompletionBlock taskCompletion = [self completionBlockForTask:dlTask];
-            SBBNetworkManagerDownloadCompletionBlock downloadCompletion = [self completionBlockForDownload:dlTask];
-            [self setCompletionBlock:taskCompletion forTask:resumeTask];
-            [self setCompletionBlock:downloadCompletion forDownload:resumeTask];
-            [self removeCompletionBlockForTask:dlTask];
-            [self removeCompletionBlockForDownload:dlTask];
-            
-            [resumeTask resume];
+            [self retryFailedDownload:(NSURLSessionDownloadTask *)task forSession:session withResumeData:resumeData];
+            // ...and exit early
             return;
         }
     }
+    
     SBBNetworkManagerTaskCompletionBlock completion = [self completionBlockForTask:task];
     if (completion) {
         completion((NSURLSessionUploadTask *)task, (NSHTTPURLResponse *)task.response, error);


### PR DESCRIPTION
- Handle 403 (presigned url expired) status code from S3 upload by retrying with a fresh presigned url.
- Handle download task errors that come with resume data by using that data to resume the task.