### PR TITLE
bug/FPHS-690

### DIFF
--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBUserSessionInfo.m
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBUserSessionInfo.m
@@ -362,8 +362,10 @@
 
 	}
 
-	[(NSMutableArray *)self.consentStatuses addObject:value_];
-
+    // Consent status can be nil if user withdrew from study and tries to login again with that account
+    if (value_ != nil) {
+        [(NSMutableArray *)self.consentStatuses addObject:value_];
+    }
 }
 - (void)addConsentStatusesObject:(SBBConsentStatus*)value_
 {


### PR DESCRIPTION
After a user withdraws, and then they try to sign in again, app was crashing because consent status was nil. 

Once I added a nil check, everything worked again with the consent flow after withdraw.