### PR TITLE
unit test upload retries

### DIFF
--- a/BridgeSDK/BridgeAPI/SBBUploadManagerInternal.h
+++ b/BridgeSDK/BridgeAPI/SBBUploadManagerInternal.h
@@ -40,11 +40,20 @@ extern NSString * const kSBBUploadRetryAfterDelayKey;
 extern NSTimeInterval kSBBDelayForRetries;
 
 @class SBBObjectManager;
-@interface SBBUploadManager () <NSURLSessionDataDelegate, NSURLSessionDownloadDelegate>
+
+@protocol SBBUploadManagerInternalProtocol <SBBUploadManagerProtocol>
+
+- (void)setUploadRequestJSON:(id)json forFile:(NSString *)fileURLString;
+- (void)setUploadSessionJSON:(id)json forFile:(NSString *)fileURLString;
+- (void)retryUploadsAfterDelay;
+- (void)checkAndRetryOrphanedUploads;
+- (void)cleanUpTempFile:(NSString *)tempFilePath;
+
+@end
+
+@interface SBBUploadManager () <SBBUploadManagerInternalProtocol, NSURLSessionDataDelegate, NSURLSessionDownloadDelegate>
 
 @property (nonatomic, strong) SBBObjectManager *cleanObjectManager;
 @property (nonatomic, strong) NSMutableDictionary *uploadCompletionHandlers;
-
-- (void)retryUploadsAfterDelay;
 
 @end

--- a/BridgeSDKTests/SBBBridgeAPIUnitTestCase.h
+++ b/BridgeSDKTests/SBBBridgeAPIUnitTestCase.h
@@ -10,6 +10,7 @@
 @import BridgeSDK;
 #import "MockURLSession.h"
 #import "SBBTestBridgeObject.h"
+#import "SBBComponentManager.h"
 
 @interface SBBBridgeAPIUnitTestCase : XCTestCase
 


### PR DESCRIPTION
also a fix for https://sagebionetworks.jira.com/browse/BRIDGE-1419, and hooking up to check and retry orphaned uploads stuck in the upload manager (as opposed to the ones stuck in the /tmp folder, which will have to be fixed from BridgeAppSDK in the encryption code that knows where the stuck files live)