### PR TITLE
Unit tests for files orphaned mid-upload

### DIFF
--- a/BridgeSDK/BridgeAPI/SBBUploadManagerInternal.h
+++ b/BridgeSDK/BridgeAPI/SBBUploadManagerInternal.h
@@ -35,6 +35,7 @@ extern NSString * const kSBBUploadAPI;
 extern NSString * const kSBBUploadCompleteAPIFormat;
 extern NSString * const kSBBUploadStatusAPIFormat;
 
+extern NSString * const kUploadFilesKey;
 extern NSString * const kSBBUploadRetryAfterDelayKey;
 
 extern NSTimeInterval kSBBDelayForRetries;
@@ -46,6 +47,7 @@ extern NSTimeInterval kSBBDelayForRetries;
 - (void)setUploadRequestJSON:(id)json forFile:(NSString *)fileURLString;
 - (void)setUploadSessionJSON:(id)json forFile:(NSString *)fileURLString;
 - (void)retryUploadsAfterDelay;
+- (NSURL *)tempFileForUploadFileToBridge:(NSURL *)fileUrl contentType:(NSString *)contentType completion:(SBBUploadManagerCompletionBlock)completion;
 - (void)checkAndRetryOrphanedUploads;
 - (void)cleanUpTempFile:(NSString *)tempFilePath;
 


### PR DESCRIPTION
(where the internal method completeUploadOfFile:withError: was never called so the copy of the file still exists in the Application Support directory; still to be handled are the ones that only still might exist in the /tmp directory, which will require code in BridgeAppSDK)