### PR TITLE
BRIDGE-1474 Setup hooks for allowing more than 4 days caching ahead and 7 days behind

### DIFF
--- a/BridgeSDK/BridgeAPI/SBBActivityManager.m
+++ b/BridgeSDK/BridgeAPI/SBBActivityManager.m
@@ -181,7 +181,7 @@ NSInteger const     kMaxAdvance  =       4; // server only supports 4 days ahead
     [self.authManager addAuthHeaderToHeaders:headers];
     
     // If caching, always request the maximum days ahead from the server so we have them cached
-    // and if the desiredDaysAhead is less that the max allowed, then fetch a minimum number of
+    // and if the desiredDaysAhead is more than the max allowed, then fetch a minimum number of
     // items per schedule.
     NSInteger desiredDaysAhead = gSBBUseCache ? gSBBCacheDaysAhead : daysAhead;
     NSInteger fetchDaysAhead = MIN(kMaxAdvance, desiredDaysAhead);

--- a/BridgeSDK/BridgeAPI/SBBActivityManager.m
+++ b/BridgeSDK/BridgeAPI/SBBActivityManager.m
@@ -44,7 +44,6 @@
 
 NSString * const kSBBActivityAPI =       ACTIVITY_API;
 NSTimeInterval const kSBB24Hours =       86400;
-NSInteger const     kDaysToCache =       7;
 NSInteger const     kMaxAdvance  =       4; // server only supports 4 days ahead
 
 @interface SBBActivityManager()<SBBActivityManagerInternalProtocol>
@@ -146,7 +145,7 @@ NSInteger const     kMaxAdvance  =       4; // server only supports 4 days ahead
 
 - (NSArray<SBBScheduledActivity *> *)savedTasksFromCachedTasks:(NSArray<SBBScheduledActivity *> *)cachedTasks
 {
-    return [self filterTasks:cachedTasks forDaysAhead:kMaxAdvance andDaysBehind:kDaysToCache excludeStillValid:YES];
+    return [self filterTasks:cachedTasks forDaysAhead:gSBBCacheDaysAhead andDaysBehind:gSBBCacheDaysBehind excludeStillValid:YES];
 }
 
 - (void)addSavedTasks:(NSArray<SBBScheduledActivity *> *)savedTasks toResourceList:(SBBResourceList *)resourceList
@@ -181,9 +180,16 @@ NSInteger const     kMaxAdvance  =       4; // server only supports 4 days ahead
     NSMutableDictionary *headers = [NSMutableDictionary dictionary];
     [self.authManager addAuthHeaderToHeaders:headers];
     
-    // if caching, always request the maximum days ahead from the server so we have them cached
-    NSInteger fetchDaysAhead = gSBBUseCache ? kMaxAdvance : daysAhead;
-    return [self.networkManager get:kSBBActivityAPI headers:headers parameters:@{@"daysAhead": @(fetchDaysAhead), @"offset": [[NSDate date] ISO8601OffsetString]} completion:^(NSURLSessionTask *task, id responseObject, NSError *error) {
+    // If caching, always request the maximum days ahead from the server so we have them cached
+    // and if the desiredDaysAhead is less that the max allowed, then fetch a minimum number of
+    // items per schedule.
+    NSInteger desiredDaysAhead = gSBBUseCache ? gSBBCacheDaysAhead : daysAhead;
+    NSInteger fetchDaysAhead = MIN(kMaxAdvance, desiredDaysAhead);
+    NSInteger fetchMinimumPerSchedule = (fetchDaysAhead < desiredDaysAhead) ? kMaxAdvance : 0;
+    NSDictionary *parameters = @{@"daysAhead": @(fetchDaysAhead),
+                                 @"minimumPerSchedule": @(fetchMinimumPerSchedule),
+                                 @"offset": [[NSDate date] ISO8601OffsetString]};
+    return [self.networkManager get:kSBBActivityAPI headers:headers parameters:parameters completion:^(NSURLSessionTask *task, id responseObject, NSError *error) {
         if (gSBBUseCache) {
             [self.cacheManager.cacheIOContext performBlock:^{
                 SBBResourceList *tasks = [self cachedTasksFromCacheManager:self.cacheManager];

--- a/BridgeSDK/BridgeSDK.h
+++ b/BridgeSDK/BridgeSDK.h
@@ -71,6 +71,13 @@ extern const unsigned char BridgeSDKVersionString[];
 #define kDefaultEnvironment SBBEnvironmentProd
 #endif
 static SBBEnvironment gDefaultEnvironment = kDefaultEnvironment;
+
+// The default number of days to cache
+extern const NSInteger SBBDefaultCacheDaysAhead;
+extern const NSInteger SBBDefaultCacheDaysBehind;
+
+// The maximum number of days that are supported for caching.
+extern const NSInteger SBBMaxSupportedCacheDays;
   
 @interface BridgeSDK : NSObject
 
@@ -88,6 +95,22 @@ static SBBEnvironment gDefaultEnvironment = kDefaultEnvironment;
  *  @param environment Which server environment to run against.
  */
 + (void)setupWithStudy:(NSString *)study useCache:(BOOL)useCache environment:(SBBEnvironment)environment;
+
+/*!
+ * Set up the Bridge SDK for the given study and server environment. Usually you would only call this version
+ * of the method from test suites, or if you have a non-DEBUG build configuration that you don't want running against
+ * the production server environment. Otherwise call the version of the setupWithStudy: method that doesn't
+ * take an environment parameter, and let the SDK use the default environment.
+ *
+ * This will register a default SBBNetworkManager instance conigured correctly for the specified environment and study.
+ * If you register a custom (or custom-configured) NetworkManager yourself, don't call this method.
+ *
+ *  @param study   A string identifier for your app's Bridge study, assigned to you by Sage Bionetworks.
+ *  @param cacheDaysAhead Number of days ahead to cache.
+ *  @param cacheDaysBehind Number of days behind to cache.
+ *  @param environment Which server environment to run against.
+ */
++ (void)setupWithStudy:(NSString *)study cacheDaysAhead:(NSInteger)cacheDaysAhead cacheDaysBehind:(NSInteger)cacheDaysBehind environment:(SBBEnvironment)environment;
 
 /*!
  * Convenience method for setting up the study with caching turned off (default).

--- a/BridgeSDK/BridgeSDK.h
+++ b/BridgeSDK/BridgeSDK.h
@@ -82,54 +82,25 @@ extern const NSInteger SBBMaxSupportedCacheDays;
 @interface BridgeSDK : NSObject
 
 /*!
- * Set up the Bridge SDK for the given study and server environment. Usually you would only call this version
- * of the method from test suites, or if you have a non-DEBUG build configuration that you don't want running against
- * the production server environment. Otherwise call the version of the setupWithStudy: method that doesn't
- * take an environment parameter, and let the SDK use the default environment.
+ * Set up the Bridge SDK for the given study and pointing at the production environment.
+ * Usually you would call this at the beginning of your AppDelegate's application:didFinishLaunchingWithOptions: method.
  *
- * This will register a default SBBNetworkManager instance conigured correctly for the specified environment and study.
- * If you register a custom (or custom-configured) NetworkManager yourself, don't call this method.
+ * This will register a default SBBNetworkManager instance conigured correctly for the specified study and appropriate
+ * server environment. If you register a custom (or custom-configured) NetworkManager yourself, don't call this method.
  *
- *  @param study   A string identifier for your app's Bridge study, assigned to you by Sage Bionetworks.
- *  @param useCache A flag indicating whether to use the SDK's built-in persistent caching. Pass NO if you want to handle this yourself.
- *  @param environment Which server environment to run against.
- */
-+ (void)setupWithStudy:(NSString *)study useCache:(BOOL)useCache environment:(SBBEnvironment)environment;
-
-/*!
- * Set up the Bridge SDK for the given study and server environment. Usually you would only call this version
- * of the method from test suites, or if you have a non-DEBUG build configuration that you don't want running against
- * the production server environment. Otherwise call the version of the setupWithStudy: method that doesn't
- * take an environment parameter, and let the SDK use the default environment.
- *
- * This will register a default SBBNetworkManager instance conigured correctly for the specified environment and study.
- * If you register a custom (or custom-configured) NetworkManager yourself, don't call this method.
+ * Caching is turned off if `cacheDaysAhead = 0` AND `cacheDaysBehind = 0`
  *
  *  @param study   A string identifier for your app's Bridge study, assigned to you by Sage Bionetworks.
  *  @param cacheDaysAhead Number of days ahead to cache.
  *  @param cacheDaysBehind Number of days behind to cache.
- *  @param environment Which server environment to run against.
  */
-+ (void)setupWithStudy:(NSString *)study cacheDaysAhead:(NSInteger)cacheDaysAhead cacheDaysBehind:(NSInteger)cacheDaysBehind environment:(SBBEnvironment)environment;
++ (void)setupWithStudy:(NSString *)study cacheDaysAhead:(NSInteger)cacheDaysAhead cacheDaysBehind:(NSInteger)cacheDaysBehind;
 
 /*!
- * Convenience method for setting up the study with caching turned off (default).
- */
-+ (void)setupWithStudy:(NSString *)study environment:(SBBEnvironment)environment;
-
-
-/*!
- * For backward compatibility only. Use setupWithStudy:environment: instead (which this method calls).
- */
-+ (void)setupWithAppPrefix:(NSString *)appPrefix environment:(SBBEnvironment)environment __deprecated;
-
-/*!
- * Set up the Bridge SDK for the given study and the appropriate server environment based on whether this is
- * a debug or release build. Usually you would call this at the beginning of your AppDelegate's
- * application:didFinishLaunchingWithOptions: method.
+ * Convenience method for setting up the study with default caching for days ahead and days behind.
  *
- * This will register a default SBBNetworkManager instance conigured correctly for the specified study and appropriate
- * server environment. If you register a custom (or custom-configured) NetworkManager yourself, don't call this method.
+ * If `useCache` is set to `YES` then this method sets up caching using `SBBDefaultCacheDaysAhead` and 
+ * `SBBDefaultCacheDaysBehind`
  *
  *  @param study   A string identifier for your app's Bridge study, assigned to you by Sage Bionetworks.
  *  @param useCache A flag indicating whether to use the SDK's built-in persistent caching. Pass NO if you want to handle this yourself.
@@ -142,9 +113,42 @@ extern const NSInteger SBBMaxSupportedCacheDays;
 + (void)setupWithStudy:(NSString *)study;
 
 /*!
+ * Set up the Bridge SDK for the given study and server environment. Usually you would only call this version
+ * of the method from test suites, or if you have a non-DEBUG build configuration that you don't want running against
+ * the production server environment. Otherwise call the version of the setupWithStudy: method that doesn't
+ * take an environment parameter, and let the SDK use the default environment.
+ *
+ * This will register a default SBBNetworkManager instance conigured correctly for the specified environment and study.
+ * If you register a custom (or custom-configured) NetworkManager yourself, don't call this method.
+ *
+ * Caching is turned off if `cacheDaysAhead = 0` AND `cacheDaysBehind = 0`
+ *
+ *  @param study   A string identifier for your app's Bridge study, assigned to you by Sage Bionetworks.
+ *  @param cacheDaysAhead Number of days ahead to cache.
+ *  @param cacheDaysBehind Number of days behind to cache.
+ *  @param environment Which server environment to run against.
+ */
++ (void)setupWithStudy:(NSString *)study cacheDaysAhead:(NSInteger)cacheDaysAhead cacheDaysBehind:(NSInteger)cacheDaysBehind environment:(SBBEnvironment)environment;
+
+/*!
+ * For backward compatibility only. Use setupWithStudy:cacheDaysAhead:cacheDaysBehind:environment: instead (which this method calls).
+ */
++ (void)setupWithStudy:(NSString *)study environment:(SBBEnvironment)environment __deprecated;
+
+/*!
+ * For backward compatibility only. Use setupWithStudy:cacheDaysAhead:cacheDaysBehind:environment: instead (which this method calls).
+ */
++ (void)setupWithStudy:(NSString *)study useCache:(BOOL)useCache environment:(SBBEnvironment)environment __deprecated;
+
+/*!
  * For backward compatibility only. Use setupWithStudy: instead (which this method calls).
  */
 + (void)setupWithAppPrefix:(NSString *)appPrefix __deprecated;
+
+/*!
+ * For backward compatibility only. Use setupWithStudy:cacheDaysAhead:cacheDaysBehind:environment: instead (which this method calls).
+ */
++ (void)setupWithAppPrefix:(NSString *)appPrefix environment:(SBBEnvironment)environment __deprecated;
 
 @end
 

--- a/BridgeSDK/BridgeSDK.m
+++ b/BridgeSDK/BridgeSDK.m
@@ -34,6 +34,10 @@
 #import "SBBAuthManagerInternal.h"
 #import "SBBCacheManager.h"
 
+const NSInteger SBBDefaultCacheDaysAhead = 4;
+const NSInteger SBBDefaultCacheDaysBehind = 7;
+const NSInteger SBBMaxSupportedCacheDays = 30;
+
 @implementation BridgeSDK
 
 + (void)setupWithStudy:(NSString *)study
@@ -61,6 +65,20 @@
     gSBBAppStudy = study;
     gSBBDefaultEnvironment = environment;
     gSBBUseCache = useCache;
+    gSBBCacheDaysAhead = SBBDefaultCacheDaysAhead;
+    gSBBCacheDaysBehind = SBBDefaultCacheDaysBehind;
+    
+    // make sure the Bridge network manager is set up as the delegate for the background session
+    [SBBComponent(SBBBridgeNetworkManager) restoreBackgroundSession:kBackgroundSessionIdentifier completionHandler:nil];
+}
+
++ (void)setupWithStudy:(NSString *)study cacheDaysAhead:(NSInteger)cacheDaysAhead cacheDaysBehind:(NSInteger)cacheDaysBehind environment:(SBBEnvironment)environment
+{
+    gSBBAppStudy = study;
+    gSBBDefaultEnvironment = environment;
+    gSBBUseCache = cacheDaysAhead > 0 || cacheDaysBehind > 0;
+    gSBBCacheDaysAhead = MIN(SBBMaxSupportedCacheDays, cacheDaysAhead);
+    gSBBCacheDaysBehind = MIN(SBBMaxSupportedCacheDays, cacheDaysBehind);
     
     // make sure the Bridge network manager is set up as the delegate for the background session
     [SBBComponent(SBBBridgeNetworkManager) restoreBackgroundSession:kBackgroundSessionIdentifier completionHandler:nil];

--- a/BridgeSDK/BridgeSDK.m
+++ b/BridgeSDK/BridgeSDK.m
@@ -63,7 +63,7 @@ const NSInteger SBBMaxSupportedCacheDays = 30;
 + (void)setupWithStudy:(NSString *)study useCache:(BOOL)useCache environment:(SBBEnvironment)environment
 {
     NSInteger cacheDaysAhead = useCache ? SBBDefaultCacheDaysAhead : 0;
-    NSInteger cacheDaysBehind = useCache ? SBBDefaultCacheDaysAhead : 0;
+    NSInteger cacheDaysBehind = useCache ? SBBDefaultCacheDaysBehind : 0;
     [self setupWithStudy:study cacheDaysAhead:cacheDaysAhead cacheDaysBehind:cacheDaysBehind environment:environment];
 }
 

--- a/BridgeSDK/BridgeSDK.m
+++ b/BridgeSDK/BridgeSDK.m
@@ -42,7 +42,7 @@ const NSInteger SBBMaxSupportedCacheDays = 30;
 
 + (void)setupWithStudy:(NSString *)study
 {
-    [self setupWithStudy:study environment:gDefaultEnvironment];
+    [self setupWithStudy:study cacheDaysAhead:0 cacheDaysBehind:0 environment:gDefaultEnvironment];
 }
 
 + (void)setupWithStudy:(NSString *)study useCache:(BOOL)useCache
@@ -57,19 +57,14 @@ const NSInteger SBBMaxSupportedCacheDays = 30;
 
 + (void)setupWithStudy:(NSString *)study environment:(SBBEnvironment)environment
 {
-    [self setupWithStudy:study useCache:NO environment:environment];
+    [self setupWithStudy:study cacheDaysAhead:0 cacheDaysBehind:0 environment:gDefaultEnvironment];
 }
 
 + (void)setupWithStudy:(NSString *)study useCache:(BOOL)useCache environment:(SBBEnvironment)environment
 {
-    gSBBAppStudy = study;
-    gSBBDefaultEnvironment = environment;
-    gSBBUseCache = useCache;
-    gSBBCacheDaysAhead = SBBDefaultCacheDaysAhead;
-    gSBBCacheDaysBehind = SBBDefaultCacheDaysBehind;
-    
-    // make sure the Bridge network manager is set up as the delegate for the background session
-    [SBBComponent(SBBBridgeNetworkManager) restoreBackgroundSession:kBackgroundSessionIdentifier completionHandler:nil];
+    NSInteger cacheDaysAhead = useCache ? SBBDefaultCacheDaysAhead : 0;
+    NSInteger cacheDaysBehind = useCache ? SBBDefaultCacheDaysAhead : 0;
+    [self setupWithStudy:study cacheDaysAhead:cacheDaysAhead cacheDaysBehind:cacheDaysBehind environment:environment];
 }
 
 + (void)setupWithStudy:(NSString *)study cacheDaysAhead:(NSInteger)cacheDaysAhead cacheDaysBehind:(NSInteger)cacheDaysBehind environment:(SBBEnvironment)environment

--- a/BridgeSDK/Internal/SBBCacheManager.h
+++ b/BridgeSDK/Internal/SBBCacheManager.h
@@ -15,6 +15,10 @@
 /// Global flag indicating whether to use internal persistent object cache. Should be set before attempting to access Bridge APIs, usually by calling the BridgeSDK setupWithStudy:useCache: class method.
 extern  BOOL gSBBUseCache;
 
+// Global integers indicating how far ahead and behind to use persistent object cache. Should be set before attempting to access Bridge APIs, usually by calling the BridgeSDK setupWithStudy:cacheDaysAhead:cacheDaysBehind class method.
+extern  NSInteger gSBBCacheDaysAhead;
+extern  NSInteger gSBBCacheDaysBehind;
+
 
 @class SBBBridgeObject;
 @class ModelObject;

--- a/BridgeSDK/Internal/SBBCacheManager.m
+++ b/BridgeSDK/Internal/SBBCacheManager.m
@@ -18,6 +18,9 @@
 
 BOOL gSBBUseCache = NO;
 
+NSInteger gSBBCacheDaysAhead = 0;
+NSInteger gSBBCacheDaysBehind = 0;
+
 static NSMutableDictionary *gCoreDataQueuesByPersistentStoreName;
 
 @interface SBBCacheManager ()<NSCacheDelegate>


### PR DESCRIPTION
This *only* addresses getting more schedules from the server (and caching them) and does not handle caching activity scores.

Required for Smart4SURE app scheduling to get more days out.