### PR TITLE
Fix sandbox-relative path bug in simulator

### DIFF
--- a/BridgeSDK/BridgeAPI/Categories/NSString+SBBAdditions.m
+++ b/BridgeSDK/BridgeAPI/Categories/NSString+SBBAdditions.m
@@ -22,9 +22,10 @@
         // simulator and device have the app uuid in a different location in the path,
         // and it might change in the future, so:
         NSRegularExpression *findUUIDRegex = [NSRegularExpression regularExpressionWithPattern:UUID_REGEX_PATTERN options:0 error:nil];
-        NSRange rangeOfUUID = [findUUIDRegex rangeOfFirstMatchInString:sandboxPath options:0 range:NSMakeRange(0, sandboxPath.length)];
-        NSString *beforeUUID = [sandboxPath substringToIndex:rangeOfUUID.location];
-        NSString *afterUUID = [sandboxPath substringFromIndex:rangeOfUUID.location + rangeOfUUID.length];
+        NSArray<NSTextCheckingResult *> *UUIDmatches = [findUUIDRegex matchesInString:sandboxPath options:0 range:NSMakeRange(0, sandboxPath.length)];
+        NSRange rangeOfLastUUID = [UUIDmatches lastObject].range;
+        NSString *beforeUUID = [sandboxPath substringToIndex:rangeOfLastUUID.location];
+        NSString *afterUUID = [sandboxPath substringFromIndex:rangeOfLastUUID.location + rangeOfLastUUID.length];
         NSString *regexPattern = @"^";
         NSString *quotedFormat = @"\\Q%@\\E";
         if (beforeUUID.length) {

--- a/BridgeSDK/BridgeAPI/SBBUploadManager.m
+++ b/BridgeSDK/BridgeAPI/SBBUploadManager.m
@@ -1065,38 +1065,6 @@ NSTimeInterval kSBBDelayForRetries = 5. * 60.; // at least 5 minutes, actually w
     if (completion) {
         completion(error);
     }
-    
-#if DEBUG
-    NSFileManager *fileMan = [NSFileManager defaultManager];
-    NSURL *homeDir = [NSURL URLWithString:NSHomeDirectory()];
-    NSDirectoryEnumerator *directoryEnumerator =
-    [fileMan enumeratorAtURL:homeDir
-  includingPropertiesForKeys:@[NSURLNameKey, NSURLIsDirectoryKey, NSURLFileSizeKey]
-                     options:0
-                errorHandler:nil];
-    
-    NSMutableDictionary<NSURL *, NSNumber *> *mutableFileInfo = [NSMutableDictionary dictionary];
-    for (NSURL *fileURL in directoryEnumerator) {
-        NSNumber *isDirectory = nil;
-        [fileURL getResourceValue:&isDirectory forKey:NSURLIsDirectoryKey error:nil];
-        
-        if (![isDirectory boolValue]) {
-            // normalize the url and add to the list
-            NSNumber *fileSize = nil;
-            [fileURL getResourceValue:&fileSize forKey:NSURLFileSizeKey error:nil];
-            if (!fileSize) {
-                fileSize = @(-1);
-            }
-            [mutableFileInfo setObject:fileSize forKey:[fileURL URLByResolvingSymlinksInPath]];
-        }
-    }
-    
-    NSLog(@"%@ files left in our sandbox:", @(mutableFileInfo.count));
-    for (NSURL *fileURL in mutableFileInfo.allKeys) {
-        NSNumber *fileSize = mutableFileInfo[fileURL];
-        NSLog(@"%@ size:%@", [fileURL.path sandboxRelativePath], fileSize);
-    };
-#endif
 }
 
 - (void)URLSession:(NSURLSession *)session didBecomeInvalidWithError:(NSError *)error


### PR DESCRIPTION
turns out simulator file paths contain 2 UUIDs, the first of which identifies the simulator (unique per simulated device & iOS version) and the last, the app itself; that latter one is the one we want to allow to change between runs of the app in a given simulator.