### PR TITLE
Fix reauth upload spam

### DIFF
--- a/BridgeSDK/Networking/SBBNetworkManager.m
+++ b/BridgeSDK/Networking/SBBNetworkManager.m
@@ -415,7 +415,7 @@ NSString *kAPIPrefix = @"webservices";
         localRetryObject.completionBlock = taskCompletion;
         localRetryObject.retryBlock = ^ {
             __strong SBBNetworkRetryObject *strongLocalRetryObject = weakLocalRetryObject; //To break retain cycle
-            [self downloadFileFromURLString:urlString retryObject:strongLocalRetryObject method:httpMethod httpHeaders:headers parameters:parameters taskDescription:description downloadCompletion:downloadCompletion taskCompletion:taskCompletion];
+            [self downloadFileFromURLString:urlString retryObject:strongLocalRetryObject method:httpMethod httpHeaders:[self headersPreparedForRetry:headers] parameters:parameters taskDescription:description downloadCompletion:downloadCompletion taskCompletion:taskCompletion];
         };
     }
     else


### PR DESCRIPTION
Dwayne was occasionally seeing bursts of upload-request-fails-with-401/app-reauth/retry-fails-with-401/rinse/repeat. I finally saw this repro’ed when testing a fix for Sarcoidosis. The culprit was that for background requests, 401s were being retried after reauth without updating the session token in the headers of the request being retried. Derp.