### PR TITLE
Fix handling of 410 on signIn

### DIFF
--- a/BridgeSDK/BridgeAPI/SBBBridgeNetworkManager.h
+++ b/BridgeSDK/BridgeAPI/SBBBridgeNetworkManager.h
@@ -34,6 +34,8 @@
 
 @protocol SBBBridgeNetworkManagerProtocol <SBBNetworkManagerProtocol>
 
+- (BOOL)checkForAndHandleUnsupportedAppVersionHTTPError:(NSError *)error;
+
 @end
 
 

--- a/BridgeSDK/BridgeAPI/SBBBridgeNetworkManager.m
+++ b/BridgeSDK/BridgeAPI/SBBBridgeNetworkManager.m
@@ -149,7 +149,7 @@
     }
 }
 
-- (void)checkForAndHandleUnsupportedAppVersionHTTPError:(NSError *)error
+- (BOOL)checkForAndHandleUnsupportedAppVersionHTTPError:(NSError *)error
 {
     // Set flag that blocks attempting further retries once this error has been received.
     // All future attempts to access services will fail.
@@ -183,6 +183,8 @@
             [[[[UIApplication sharedApplication] keyWindow] rootViewController] presentViewController:alertController animated:YES completion:nil];
         }
     }
+    
+    return _unsupportedAppVersion;
 }
 
 - (void)checkForAndHandleServerPreconditionNotMetHTTPError:(NSError *)error task:(NSURLSessionTask *)task responseObject:(id)responseObject retryObject:(SBBNetworkRetryObject *)retryObject


### PR DESCRIPTION
SBBAuthManager uses a vanilla SBBNetworkManager, not a Bridge one, so we need to handle this error condition from here as well