### PR TITLE
Don’t use standardUserDefaults by default

### DIFF
--- a/BridgeSDK/BridgeAPI/SBBBridgeInfo.m
+++ b/BridgeSDK/BridgeAPI/SBBBridgeInfo.m
@@ -88,6 +88,8 @@ const NSInteger SBBMaxSupportedCacheDays = 30;
     self.environment = info.environment;
     self.certificateName = info.certificateName;
     self.appGroupIdentifier = info.appGroupIdentifier;
+    self.usesStandardUserDefaults = info.usesStandardUserDefaults;
+    self.userDefaultsSuiteName = info.userDefaultsSuiteName;
 }
 
 - (NSString *)studyIdentifier
@@ -152,24 +154,24 @@ const NSInteger SBBMaxSupportedCacheDays = 30;
     _bridgeInfo[NSStringFromSelector(@selector(appGroupIdentifier))] = [appGroupIdentifier copy];
 }
 
-- (BOOL)useStandardUserDefaults
+- (BOOL)usesStandardUserDefaults
 {
-    return [((NSNumber *)_bridgeInfo[NSStringFromSelector(@selector(useStandardUserDefaults))]) boolValue];
+    return [((NSNumber *)_bridgeInfo[NSStringFromSelector(@selector(usesStandardUserDefaults))]) boolValue];
 }
 
-- (void)setUseStandardUserDefaults:(BOOL)useStandardUserDefaults
+- (void)setUsesStandardUserDefaults:(BOOL)usesStandardUserDefaults
 {
-    _bridgeInfo[NSStringFromSelector(@selector(useStandardUserDefaults))] = @(useStandardUserDefaults);
+    _bridgeInfo[NSStringFromSelector(@selector(usesStandardUserDefaults))] = @(usesStandardUserDefaults);
 }
 
-- (NSString *)userDefaultsSuite
+- (NSString *)userDefaultsSuiteName
 {
-    return _bridgeInfo[NSStringFromSelector(@selector(userDefaultsSuite))];
+    return _bridgeInfo[NSStringFromSelector(@selector(userDefaultsSuiteName))];
 }
 
-- (void)setUserDefaultsSuite:(NSString *)userDefaultsSuite
+- (void)setUserDefaultsSuiteName:(NSString *)userDefaultsSuiteName
 {
-    _bridgeInfo[NSStringFromSelector(@selector(userDefaultsSuite))] = [userDefaultsSuite copy];
+    _bridgeInfo[NSStringFromSelector(@selector(userDefaultsSuiteName))] = [userDefaultsSuiteName copy];
 }
 
 @end

--- a/BridgeSDK/BridgeAPI/SBBBridgeInfo.m
+++ b/BridgeSDK/BridgeAPI/SBBBridgeInfo.m
@@ -105,7 +105,7 @@ const NSInteger SBBMaxSupportedCacheDays = 30;
     return [((NSNumber *)_bridgeInfo[NSStringFromSelector(@selector(cacheDaysAhead))]) integerValue];
 }
 
-- (void) setCacheDaysAhead:(NSInteger)cacheDaysAhead
+- (void)setCacheDaysAhead:(NSInteger)cacheDaysAhead
 {
     NSUInteger daysAhead = MIN(SBBMaxSupportedCacheDays, cacheDaysAhead);
     _bridgeInfo[NSStringFromSelector(@selector(cacheDaysAhead))] = @(daysAhead);
@@ -150,6 +150,26 @@ const NSInteger SBBMaxSupportedCacheDays = 30;
 - (void)setAppGroupIdentifier:(NSString *)appGroupIdentifier
 {
     _bridgeInfo[NSStringFromSelector(@selector(appGroupIdentifier))] = [appGroupIdentifier copy];
+}
+
+- (BOOL)useStandardUserDefaults
+{
+    return [((NSNumber *)_bridgeInfo[NSStringFromSelector(@selector(useStandardUserDefaults))]) boolValue];
+}
+
+- (void)setUseStandardUserDefaults:(BOOL)useStandardUserDefaults
+{
+    _bridgeInfo[NSStringFromSelector(@selector(useStandardUserDefaults))] = @(useStandardUserDefaults);
+}
+
+- (NSString *)userDefaultsSuite
+{
+    return _bridgeInfo[NSStringFromSelector(@selector(userDefaultsSuite))];
+}
+
+- (void)setUserDefaultsSuite:(NSString *)userDefaultsSuite
+{
+    _bridgeInfo[NSStringFromSelector(@selector(userDefaultsSuite))] = [userDefaultsSuite copy];
 }
 
 @end

--- a/BridgeSDK/BridgeAPI/SBBBridgeInfoProtocol.h
+++ b/BridgeSDK/BridgeAPI/SBBBridgeInfoProtocol.h
@@ -68,20 +68,20 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Tells the Bridge libraries to use the standard user defaults suite.
  
- @note This flag is intended only for backward compatibility when upgrading apps built with older versions of Bridge libraries that used the standard user defaults suite. It will be ignored in any case if either userDefaultsSuite or appGroupIdentifier are set.
+ @note This flag is intended only for backward compatibility when upgrading apps built with older versions of Bridge libraries that used the standard user defaults suite. It will be ignored in any case if either userDefaultsSuiteName or appGroupIdentifier are set.
  */
-@property (nonatomic, readonly) BOOL useStandardUserDefaults;
+@property (nonatomic, readonly) BOOL usesStandardUserDefaults;
 
 /**
- The user defaults suite for the Bridge libraries to use internally. Only needs to be set if you want
+ The name of the user defaults suite for the Bridge libraries to use internally. Only needs to be set if you want
  the Bridge libraries to use something other than their default internal suite name (org.sagebase.Bridge)
  or, in conjunction with appGroupIdentifier, to have them use a different suite other than the
  shared suite.
  */
-@property (nonatomic, readonly) NSString * _Nullable userDefaultsSuite;
+@property (nonatomic, readonly) NSString * _Nullable userDefaultsSuiteName;
 
 /**
- This property, if set, is used for the suite name of NSUserDefaults (if userDefaultsSuite
+ This property, if set, is used for the suite name of NSUserDefaults (if userDefaultsSuiteName
  is not explicitly set), and for the name of the shared container, which is used both to configure the
  background session and as the place to store temporary copies of files being uploaded to Bridge
  (if provided).

--- a/BridgeSDK/BridgeAPI/SBBBridgeInfoProtocol.h
+++ b/BridgeSDK/BridgeAPI/SBBBridgeInfoProtocol.h
@@ -66,9 +66,25 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) SBBEnvironment environment;
 
 /**
- App group identifier used for the suite name of NSUserDefaults, and for the name of the shared
- container, which is used both to configure the background session and as the place to store
- temporary copies of files being uploaded to Bridge (if provided).
+ Tells the Bridge libraries to use the standard user defaults suite.
+ 
+ @note This flag is intended only for backward compatibility when upgrading apps built with older versions of Bridge libraries that used the standard user defaults suite. It will be ignored in any case if either userDefaultsSuite or appGroupIdentifier are set.
+ */
+@property (nonatomic, readonly) BOOL useStandardUserDefaults;
+
+/**
+ The user defaults suite for the Bridge libraries to use internally. Only needs to be set if you want
+ the Bridge libraries to use something other than their default internal suite name (org.sagebase.Bridge)
+ or, in conjunction with appGroupIdentifier, to have them use a different suite other than the
+ shared suite.
+ */
+@property (nonatomic, readonly) NSString * _Nullable userDefaultsSuite;
+
+/**
+ This property, if set, is used for the suite name of NSUserDefaults (if userDefaultsSuite
+ is not explicitly set), and for the name of the shared container, which is used both to configure the
+ background session and as the place to store temporary copies of files being uploaded to Bridge
+ (if provided).
  */
 @property (nonatomic, readonly, copy) NSString * _Nullable appGroupIdentifier;
 

--- a/BridgeSDK/BridgeSDK.h
+++ b/BridgeSDK/BridgeSDK.h
@@ -84,7 +84,7 @@ extern const NSInteger SBBDefaultCacheDaysBehind;
 extern const NSInteger SBBMaxSupportedCacheDays;
     
 // The default NSUserDefaults suite to use if not otherwise specified at setup time
-extern const NSString * _Nullable SBBDefaultUserDefaultsSuite;
+extern const NSString * _Nullable SBBDefaultUserDefaultsSuiteName;
   
 @interface BridgeSDK : NSObject
 

--- a/BridgeSDK/BridgeSDK.h
+++ b/BridgeSDK/BridgeSDK.h
@@ -82,6 +82,9 @@ extern const NSInteger SBBDefaultCacheDaysBehind;
 
 // The maximum number of days that are supported for caching.
 extern const NSInteger SBBMaxSupportedCacheDays;
+    
+// The default NSUserDefaults suite to use if not otherwise specified at setup time
+extern const NSString * _Nullable SBBDefaultUserDefaultsSuite;
   
 @interface BridgeSDK : NSObject
 

--- a/BridgeSDK/BridgeSDK.m
+++ b/BridgeSDK/BridgeSDK.m
@@ -39,7 +39,7 @@
 const NSInteger SBBDefaultCacheDaysAhead = 4;
 const NSInteger SBBDefaultCacheDaysBehind = 7;
 
-const NSString *SBBDefaultUserDefaultsSuite = @"org.sagebase.Bridge";
+const NSString *SBBDefaultUserDefaultsSuiteName = @"org.sagebase.Bridge";
 
 id<SBBBridgeErrorUIDelegate> gSBBErrorUIDelegate = nil;
 
@@ -135,14 +135,14 @@ id<SBBBridgeErrorUIDelegate> gSBBErrorUIDelegate = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         SBBBridgeInfo *sharedInfo = [SBBBridgeInfo shared];
-        if (sharedInfo.userDefaultsSuite.length > 0) {
-            bridgeUserDefaults = [[NSUserDefaults alloc] initWithSuiteName:sharedInfo.userDefaultsSuite];
+        if (sharedInfo.userDefaultsSuiteName.length > 0) {
+            bridgeUserDefaults = [[NSUserDefaults alloc] initWithSuiteName:sharedInfo.userDefaultsSuiteName];
         } else if (sharedInfo.appGroupIdentifier.length > 0) {
             bridgeUserDefaults = [[NSUserDefaults alloc] initWithSuiteName:sharedInfo.appGroupIdentifier];
-        } else if (sharedInfo.useStandardUserDefaults) {
+        } else if (sharedInfo.usesStandardUserDefaults) {
             bridgeUserDefaults = [NSUserDefaults standardUserDefaults];
         } else {
-            bridgeUserDefaults = [[NSUserDefaults alloc] initWithSuiteName:(NSString *)SBBDefaultUserDefaultsSuite];
+            bridgeUserDefaults = [[NSUserDefaults alloc] initWithSuiteName:(NSString *)SBBDefaultUserDefaultsSuiteName];
         }
     });
     

--- a/BridgeSDK/BridgeSDK.m
+++ b/BridgeSDK/BridgeSDK.m
@@ -39,6 +39,8 @@
 const NSInteger SBBDefaultCacheDaysAhead = 4;
 const NSInteger SBBDefaultCacheDaysBehind = 7;
 
+const NSString *SBBDefaultUserDefaultsSuite = @"org.sagebase.Bridge";
+
 id<SBBBridgeErrorUIDelegate> gSBBErrorUIDelegate = nil;
 
 @implementation BridgeSDK
@@ -132,10 +134,15 @@ id<SBBBridgeErrorUIDelegate> gSBBErrorUIDelegate = nil;
     static NSUserDefaults *bridgeUserDefaults = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        if ([SBBBridgeInfo shared].appGroupIdentifier.length > 0) {
-            bridgeUserDefaults = [[NSUserDefaults alloc] initWithSuiteName:[SBBBridgeInfo shared].appGroupIdentifier];
-        } else {
+        SBBBridgeInfo *sharedInfo = [SBBBridgeInfo shared];
+        if (sharedInfo.userDefaultsSuite.length > 0) {
+            bridgeUserDefaults = [[NSUserDefaults alloc] initWithSuiteName:sharedInfo.userDefaultsSuite];
+        } else if (sharedInfo.appGroupIdentifier.length > 0) {
+            bridgeUserDefaults = [[NSUserDefaults alloc] initWithSuiteName:sharedInfo.appGroupIdentifier];
+        } else if (sharedInfo.useStandardUserDefaults) {
             bridgeUserDefaults = [NSUserDefaults standardUserDefaults];
+        } else {
+            bridgeUserDefaults = [[NSUserDefaults alloc] initWithSuiteName:(NSString *)SBBDefaultUserDefaultsSuite];
         }
     });
     


### PR DESCRIPTION
unless there’s a flag to that effect in BridgeInfo in the setup call