### PR TITLE
Change the documentation deployment location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,28 +12,15 @@ script:
 #  - ./travis/run-tests.sh
   - ./travis/build-docs.sh
 
-# deploy lastest docs from master
-deploy:
-  provider: s3
-  access_key_id: AKIAICA2M6XGX62Q4NTQ
-  secret_access_key:
-    secure: KkdUcM+2ChVUj7B39WMfjEyx9T7N9iTInB6MGy00A8yv4LH1o74LVgMy7RiZ8hAceaxruAP/r/LD6lHxjBtJUHc/PairO+0Gm8nHg4r5LDbF6dnUgEsgtXa+j/XL4IfFuX88bvjYYEnkhMqvDYv1RsGw/CHdAoJ6T0qPo4Sod6+zOgysYduxjBpbPcvPqcyK3gj4NUd2LqbIzcJ2pE2C3KNMPFqkyPYIYsXgcYC6zMhDYzAnekqAe8OISEpxmC5hp/kT2qxFonOAKMqK3DbytMd6ly7NPJzxU2FN7hfAwLCfTlkR4HVd0pEDTxjpDahwdJSU8kuj3V920DgCq5O3l4FL3XxSOsQOFwBQPn/VCemyQ2vkIqfcXb/gSyE9VMgP2O8ADZVL6C4ZVIZZvHgVtaptqh6bsUZnEhr5n64cX2uiyos+72QjPLreeIA48E6dZvk2C6bjpqVO1PYHzFU/geO5ojnULzIeK2bMTRwUBCZLrmHn5pFTqwwGbCfESJBknGjrB6jyYbdnKEJbtOz7BrGWMi2pmnYZZDbk7FVdYH5bi4wYFvRacEqlFAs5b2au7qNtElANaNCCrxLVUtKkKguosurA1LlrSMYcIsCNuFJ7Nu5sJqyxtKBMiDJs99rdb62rw6iczn1/0GgJI7RL0S/vG19WahiqfNmswblIQ3A=
-  bucket: ios-apps.sagebridge.org
-  skip_cleanup: true
-  local_dir: Documentation
-  upload-dir: org.sagebase.BridgeSDK/Documentation/latest
-  on:
-    branch: master
-
 # deploy docs on a tag
 deploy:
   provider: s3
-  access_key_id: AKIAICA2M6XGX62Q4NTQ
+  access_key_id: AKIAI6OL6JAPHW5QJTLQ
   secret_access_key:
-    secure: KkdUcM+2ChVUj7B39WMfjEyx9T7N9iTInB6MGy00A8yv4LH1o74LVgMy7RiZ8hAceaxruAP/r/LD6lHxjBtJUHc/PairO+0Gm8nHg4r5LDbF6dnUgEsgtXa+j/XL4IfFuX88bvjYYEnkhMqvDYv1RsGw/CHdAoJ6T0qPo4Sod6+zOgysYduxjBpbPcvPqcyK3gj4NUd2LqbIzcJ2pE2C3KNMPFqkyPYIYsXgcYC6zMhDYzAnekqAe8OISEpxmC5hp/kT2qxFonOAKMqK3DbytMd6ly7NPJzxU2FN7hfAwLCfTlkR4HVd0pEDTxjpDahwdJSU8kuj3V920DgCq5O3l4FL3XxSOsQOFwBQPn/VCemyQ2vkIqfcXb/gSyE9VMgP2O8ADZVL6C4ZVIZZvHgVtaptqh6bsUZnEhr5n64cX2uiyos+72QjPLreeIA48E6dZvk2C6bjpqVO1PYHzFU/geO5ojnULzIeK2bMTRwUBCZLrmHn5pFTqwwGbCfESJBknGjrB6jyYbdnKEJbtOz7BrGWMi2pmnYZZDbk7FVdYH5bi4wYFvRacEqlFAs5b2au7qNtElANaNCCrxLVUtKkKguosurA1LlrSMYcIsCNuFJ7Nu5sJqyxtKBMiDJs99rdb62rw6iczn1/0GgJI7RL0S/vG19WahiqfNmswblIQ3A=
-  bucket: ios-apps.sagebridge.org
+    secure: FN9DKqIZmYdxaOJNAQf0/R0I0IlcWMi8417Mz4XAATs92ZauHdeTrQKeeRtFT2i8LHHVzxy1KEqJt5Uo3pOvH+Awn6TTuJBR+3aOrKh88L3Qcxcl2NFdbamR2xeBkSAUfGaiLTYEQuB+QbWlVKqilGvD2wAQc37+pUv207prgJg=
+  bucket: developer.sagebridge.org
   skip_cleanup: true
   local_dir: Documentation
-  upload-dir: org.sagebase.BridgeSDK/Documentation/$TRAVIS_TAG
+  upload-dir: "$TRAVIS_XCODE_PROJECT/$TRAVIS_TAG"
   on:
     tags: true


### PR DESCRIPTION
SDK are hosted on https://developer.sagebridge.org so deployments so we
should deploy the docs there.  Also only deploy docs when a tag is made.