### PR TITLE
Setup configuration for testing

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -38,7 +38,12 @@ platform :ios do
   desc "Runs all the tests"
   lane :test do |options|
     if options[:scheme]
-      scan(scheme: options[:scheme])
+       scan(
+         scheme: options[:scheme],
+         xcargs: [
+           "SAGE_ADMIN_EMAIL=#{ENV['SAGE_ADMIN_EMAIL']}",
+           "SAGE_ADMIN_PASSWORD=#{ENV['SAGE_ADMIN_PASSWORD']}"]
+        )
     else
       scan
     end

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -7,6 +7,7 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
 fi
 if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
     bundle exec fastlane doc scheme:"BridgeSDK"
+    cp BridgeAdminCredentials.plist ../BridgeAdminCredentials.plist
     bundle exec fastlane test scheme:"BridgeSDK"
 fi
 exit $?


### PR DESCRIPTION
This sets up the configuration file need by test and
passes the SAGE env variables to the xcode build.

This change is dependent on PR 139