### PR TITLE
Bridge 1772 save activity result summary

### DIFF
--- a/BridgeSDK.xcodeproj/project.pbxproj
+++ b/BridgeSDK.xcodeproj/project.pbxproj
@@ -310,7 +310,7 @@
 		80855F7319BE27ED006601C7 /* SBBNetworkManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 80855F6C19BE27ED006601C7 /* SBBNetworkManager.m */; };
 		80855F7D19BE41C9006601C7 /* Reachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 80855F7B19BE41C9006601C7 /* Reachability.h */; };
 		80855F7E19BE41C9006601C7 /* Reachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 80855F7C19BE41C9006601C7 /* Reachability.m */; };
-		808D03BA1E96BC810030F23E /* SBBJSONValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 808D03B91E96BC810030F23E /* SBBJSONValue.h */; };
+		808D03BA1E96BC810030F23E /* SBBJSONValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 808D03B91E96BC810030F23E /* SBBJSONValue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		808D03CC1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceList.h in Headers */ = {isa = PBXBuildFile; fileRef = 808D03C91E96CDCC0030F23E /* _SBBForwardCursorPagedResourceList.h */; };
 		808D03CD1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceList.m in Sources */ = {isa = PBXBuildFile; fileRef = 808D03CA1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceList.m */; };
 		808D03CE1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceListInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 808D03CB1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceListInternal.h */; };

--- a/BridgeSDK.xcodeproj/project.pbxproj
+++ b/BridgeSDK.xcodeproj/project.pbxproj
@@ -310,6 +310,14 @@
 		80855F7319BE27ED006601C7 /* SBBNetworkManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 80855F6C19BE27ED006601C7 /* SBBNetworkManager.m */; };
 		80855F7D19BE41C9006601C7 /* Reachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 80855F7B19BE41C9006601C7 /* Reachability.h */; };
 		80855F7E19BE41C9006601C7 /* Reachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 80855F7C19BE41C9006601C7 /* Reachability.m */; };
+		808D03BA1E96BC810030F23E /* SBBJSONValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 808D03B91E96BC810030F23E /* SBBJSONValue.h */; };
+		808D03CC1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceList.h in Headers */ = {isa = PBXBuildFile; fileRef = 808D03C91E96CDCC0030F23E /* _SBBForwardCursorPagedResourceList.h */; };
+		808D03CD1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceList.m in Sources */ = {isa = PBXBuildFile; fileRef = 808D03CA1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceList.m */; };
+		808D03CE1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceListInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 808D03CB1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceListInternal.h */; };
+		808D03D21E96CDF30030F23E /* SBBForwardCursorPagedResourceList.h in Headers */ = {isa = PBXBuildFile; fileRef = 808D03CF1E96CDF30030F23E /* SBBForwardCursorPagedResourceList.h */; };
+		808D03D31E96CDF30030F23E /* SBBForwardCursorPagedResourceList.m in Sources */ = {isa = PBXBuildFile; fileRef = 808D03D01E96CDF30030F23E /* SBBForwardCursorPagedResourceList.m */; };
+		808D03D41E96CDF30030F23E /* SBBForwardCursorPagedResourceListInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 808D03D11E96CDF30030F23E /* SBBForwardCursorPagedResourceListInternal.h */; };
+		808D03D61E96D6770030F23E /* SBBJSONValue.m in Sources */ = {isa = PBXBuildFile; fileRef = 808D03D51E96D6770030F23E /* SBBJSONValue.m */; };
 		80AF00801CAB267B009A222B /* SBBTestBridgeObjects.m in Sources */ = {isa = PBXBuildFile; fileRef = 8017AF6319D9C3AF001AF9BA /* SBBTestBridgeObjects.m */; };
 		80B2C43E1E3A59D2001F9FEA /* SBBEncryptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 80B2C43C1E3A59D2001F9FEA /* SBBEncryptor.h */; };
 		80B2C43F1E3A59D2001F9FEA /* SBBEncryptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 80B2C43D1E3A59D2001F9FEA /* SBBEncryptor.m */; };
@@ -830,6 +838,14 @@
 		80855F6C19BE27ED006601C7 /* SBBNetworkManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBBNetworkManager.m; sourceTree = "<group>"; };
 		80855F7B19BE41C9006601C7 /* Reachability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Reachability.h; sourceTree = "<group>"; };
 		80855F7C19BE41C9006601C7 /* Reachability.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Reachability.m; sourceTree = "<group>"; };
+		808D03B91E96BC810030F23E /* SBBJSONValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SBBJSONValue.h; sourceTree = "<group>"; };
+		808D03C91E96CDCC0030F23E /* _SBBForwardCursorPagedResourceList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _SBBForwardCursorPagedResourceList.h; sourceTree = "<group>"; };
+		808D03CA1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = _SBBForwardCursorPagedResourceList.m; sourceTree = "<group>"; };
+		808D03CB1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceListInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _SBBForwardCursorPagedResourceListInternal.h; sourceTree = "<group>"; };
+		808D03CF1E96CDF30030F23E /* SBBForwardCursorPagedResourceList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SBBForwardCursorPagedResourceList.h; sourceTree = "<group>"; };
+		808D03D01E96CDF30030F23E /* SBBForwardCursorPagedResourceList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBBForwardCursorPagedResourceList.m; sourceTree = "<group>"; };
+		808D03D11E96CDF30030F23E /* SBBForwardCursorPagedResourceListInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SBBForwardCursorPagedResourceListInternal.h; sourceTree = "<group>"; };
+		808D03D51E96D6770030F23E /* SBBJSONValue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBBJSONValue.m; sourceTree = "<group>"; };
 		80B2C43C1E3A59D2001F9FEA /* SBBEncryptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SBBEncryptor.h; sourceTree = "<group>"; };
 		80B2C43D1E3A59D2001F9FEA /* SBBEncryptor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBBEncryptor.m; sourceTree = "<group>"; };
 		80B2C4431E3A5CED001F9FEA /* SBBDataArchive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SBBDataArchive.h; sourceTree = "<group>"; };
@@ -908,6 +924,7 @@
 		80C87F081C18E55A00FE8A63 /* _SBBDataGroups.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = _SBBDataGroups.m; sourceTree = "<group>"; };
 		80C87F0B1C18E61000FE8A63 /* SBBDataGroups.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SBBDataGroups.h; sourceTree = "<group>"; };
 		80C87F0C1C18E61000FE8A63 /* SBBDataGroups.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBBDataGroups.m; sourceTree = "<group>"; };
+		80CE622C1E8DDBBC00CD154C /* SBBDataModelV4.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = SBBDataModelV4.xcdatamodel; sourceTree = "<group>"; };
 		80D517331CADD0A8002D2C06 /* NSObject+SBBAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+SBBAdditions.h"; sourceTree = "<group>"; };
 		80D517341CADD0A8002D2C06 /* NSObject+SBBAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+SBBAdditions.m"; sourceTree = "<group>"; };
 		80D517491CAF4453002D2C06 /* _SBBSurveyInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _SBBSurveyInternal.h; sourceTree = "<group>"; };
@@ -1055,6 +1072,9 @@
 				800E795219ED74A600EEE612 /* SBBDecimalConstraints.m */,
 				800E795319ED74A600EEE612 /* SBBDurationConstraints.h */,
 				800E795419ED74A600EEE612 /* SBBDurationConstraints.m */,
+				808D03CF1E96CDF30030F23E /* SBBForwardCursorPagedResourceList.h */,
+				808D03D11E96CDF30030F23E /* SBBForwardCursorPagedResourceListInternal.h */,
+				808D03D01E96CDF30030F23E /* SBBForwardCursorPagedResourceList.m */,
 				606FDE231A2F9E4300898466 /* SBBIdentifierHolder.h */,
 				606FDE241A2F9E4300898466 /* SBBIdentifierHolder.m */,
 				80E8196D1A83E8EB00513919 /* SBBImage.h */,
@@ -1149,6 +1169,8 @@
 				8077477F1E28289C000C13CD /* SBBBridgeAppDelegate.h */,
 				FFEA839B1C0E58FF000E7560 /* SBBBridgeErrorUIDelegate.h */,
 				804C109D1E2841C9004B68E6 /* SBBBridgeInfoProtocol.h */,
+				808D03B91E96BC810030F23E /* SBBJSONValue.h */,
+				808D03D51E96D6770030F23E /* SBBJSONValue.m */,
 			);
 			name = Protocols;
 			sourceTree = "<group>";
@@ -1576,6 +1598,9 @@
 				800E792A19ED740F00EEE612 /* _SBBDecimalConstraints.m */,
 				800E792B19ED740F00EEE612 /* _SBBDurationConstraints.h */,
 				800E792C19ED740F00EEE612 /* _SBBDurationConstraints.m */,
+				808D03C91E96CDCC0030F23E /* _SBBForwardCursorPagedResourceList.h */,
+				808D03CB1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceListInternal.h */,
+				808D03CA1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceList.m */,
 				606FDE1F1A2F9DC800898466 /* _SBBIdentifierHolder.h */,
 				606FDE201A2F9DC800898466 /* _SBBIdentifierHolder.m */,
 				80E819601A83E89E00513919 /* _SBBImage.h */,
@@ -1683,6 +1708,7 @@
 				80D5174A1CAF4454002D2C06 /* _SBBSurveyInternal.h in Headers */,
 				8026D67A19E77518008942B0 /* SBBUploadManager.h in Headers */,
 				800E795719ED74A600EEE612 /* SBBDateTimeConstraints.h in Headers */,
+				808D03CC1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceList.h in Headers */,
 				6056DE111CF61ECD00C21E82 /* _SBBStudyParticipantInternal.h in Headers */,
 				807AE2DD1B62ADB1002588BB /* SBBSurveyManagerInternal.h in Headers */,
 				80E819731A83E8EB00513919 /* SBBImage.h in Headers */,
@@ -1706,11 +1732,13 @@
 				80B2C6341E3AD493001F9FEA /* ZZArchive.h in Headers */,
 				800E794519ED744000EEE612 /* _SBBSurveyQuestionOption.h in Headers */,
 				80B2C43E1E3A59D2001F9FEA /* SBBEncryptor.h in Headers */,
+				808D03CE1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceListInternal.h in Headers */,
 				80F7C34B19E5DC0D00574800 /* SBBBridgeObjects.h in Headers */,
 				800E794719ED744000EEE612 /* _SBBTimeConstraints.h in Headers */,
 				80B2C6451E3AD493001F9FEA /* ZZDeflateOutputStream.h in Headers */,
 				606FDE251A2F9E4300898466 /* SBBIdentifierHolder.h in Headers */,
 				804C10A11E2847FE004B68E6 /* SBBBridgeInfo.h in Headers */,
+				808D03D21E96CDF30030F23E /* SBBForwardCursorPagedResourceList.h in Headers */,
 				80104A5C19D4CD9E001F2573 /* SBBUserProfile.h in Headers */,
 				800E795519ED74A600EEE612 /* SBBDateConstraints.h in Headers */,
 				800E794319ED744000EEE612 /* _SBBStringConstraints.h in Headers */,
@@ -1722,6 +1750,7 @@
 				80BA3D991C3F19D400AA70FB /* SBBConsentStatus.h in Headers */,
 				80B2C4911E3AA80D001F9FEA /* ZipZap+Namespace.h in Headers */,
 				8017AF7019DA0359001AF9BA /* NSError+SBBAdditions.h in Headers */,
+				808D03D41E96CDF30030F23E /* SBBForwardCursorPagedResourceListInternal.h in Headers */,
 				8017AF7619DA038D001AF9BA /* NSDate+SBBAdditions.h in Headers */,
 				80B2C6351E3AD493001F9FEA /* ZZArchiveEntry.h in Headers */,
 				60F1E4161A420E96009B380E /* _SBBActivity.h in Headers */,
@@ -1742,6 +1771,7 @@
 				8026D68A19E888DB008942B0 /* SBBUploadSession.h in Headers */,
 				6056DE231CF61F4000C21E82 /* SBBSurveyInternal.h in Headers */,
 				80F7C35119E5DC0D00574800 /* SBBSurveyQuestion.h in Headers */,
+				808D03BA1E96BC810030F23E /* SBBJSONValue.h in Headers */,
 				80855F7119BE27ED006601C7 /* SBBErrors.h in Headers */,
 				800E796B19ED74C500EEE612 /* SBBSurveyQuestionOption.h in Headers */,
 				80FA54DF1A25110E00EDE46E /* SBBCacheManager.h in Headers */,
@@ -2318,10 +2348,12 @@
 				807AE2FF1B62E98C002588BB /* SBBUserSessionInfo.m in Sources */,
 				800E792E19ED740F00EEE612 /* _SBBDateConstraints.m in Sources */,
 				80B2C6591E3AD493001F9FEA /* ZZStandardCryptoEngine.cpp in Sources */,
+				808D03CD1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceList.m in Sources */,
 				807AE2EF1B62E8C3002588BB /* _SBBUserSessionInfo.m in Sources */,
 				80B2C4461E3A5CED001F9FEA /* SBBDataArchive.m in Sources */,
 				80F88E541AF991B10090D462 /* _SBBScheduledActivity.m in Sources */,
 				80F88E4C1AF98DA70090D462 /* SBBActivityManager.m in Sources */,
+				808D03D31E96CDF30030F23E /* SBBForwardCursorPagedResourceList.m in Sources */,
 				800E796419ED74B600EEE612 /* SBBIntegerConstraints.m in Sources */,
 				800E796619ED74B600EEE612 /* SBBMultiValueConstraints.m in Sources */,
 				80B2C6391E3AD493001F9FEA /* ZZAESDecryptInputStream.mm in Sources */,
@@ -2336,6 +2368,7 @@
 				8017AF7719DA038D001AF9BA /* NSDate+SBBAdditions.m in Sources */,
 				8051DCE21A1E6FDB0068D06E /* RNEncryptor.m in Sources */,
 				80B2C6561E3AD493001F9FEA /* ZZOldArchiveEntryWriter.mm in Sources */,
+				808D03D61E96D6770030F23E /* SBBJSONValue.m in Sources */,
 				8026D69319E892B5008942B0 /* SBBUploadRequest.m in Sources */,
 				80F7C35219E5DC0D00574800 /* SBBSurveyQuestion.m in Sources */,
 				80855F7319BE27ED006601C7 /* SBBNetworkManager.m in Sources */,
@@ -2982,6 +3015,7 @@
 		80F7C33919E5DC0D00574800 /* SBBDataModel.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				80CE622C1E8DDBBC00CD154C /* SBBDataModelV4.xcdatamodel */,
 				80561DA71E69EF7E005FBFA3 /* SBBDataModelV3.xcdatamodel */,
 				80C565751E40FC4000D83A72 /* SBBDataModelV2.xcdatamodel */,
 				8055F52A1E05FD2A009F3485 /* SBBDataModelV1.xcdatamodel */,

--- a/BridgeSDK.xcodeproj/project.pbxproj
+++ b/BridgeSDK.xcodeproj/project.pbxproj
@@ -311,10 +311,10 @@
 		80855F7D19BE41C9006601C7 /* Reachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 80855F7B19BE41C9006601C7 /* Reachability.h */; };
 		80855F7E19BE41C9006601C7 /* Reachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 80855F7C19BE41C9006601C7 /* Reachability.m */; };
 		808D03BA1E96BC810030F23E /* SBBJSONValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 808D03B91E96BC810030F23E /* SBBJSONValue.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		808D03CC1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceList.h in Headers */ = {isa = PBXBuildFile; fileRef = 808D03C91E96CDCC0030F23E /* _SBBForwardCursorPagedResourceList.h */; };
+		808D03CC1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceList.h in Headers */ = {isa = PBXBuildFile; fileRef = 808D03C91E96CDCC0030F23E /* _SBBForwardCursorPagedResourceList.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		808D03CD1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceList.m in Sources */ = {isa = PBXBuildFile; fileRef = 808D03CA1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceList.m */; };
 		808D03CE1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceListInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 808D03CB1E96CDCC0030F23E /* _SBBForwardCursorPagedResourceListInternal.h */; };
-		808D03D21E96CDF30030F23E /* SBBForwardCursorPagedResourceList.h in Headers */ = {isa = PBXBuildFile; fileRef = 808D03CF1E96CDF30030F23E /* SBBForwardCursorPagedResourceList.h */; };
+		808D03D21E96CDF30030F23E /* SBBForwardCursorPagedResourceList.h in Headers */ = {isa = PBXBuildFile; fileRef = 808D03CF1E96CDF30030F23E /* SBBForwardCursorPagedResourceList.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		808D03D31E96CDF30030F23E /* SBBForwardCursorPagedResourceList.m in Sources */ = {isa = PBXBuildFile; fileRef = 808D03D01E96CDF30030F23E /* SBBForwardCursorPagedResourceList.m */; };
 		808D03D41E96CDF30030F23E /* SBBForwardCursorPagedResourceListInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 808D03D11E96CDF30030F23E /* SBBForwardCursorPagedResourceListInternal.h */; };
 		808D03D61E96D6770030F23E /* SBBJSONValue.m in Sources */ = {isa = PBXBuildFile; fileRef = 808D03D51E96D6770030F23E /* SBBJSONValue.m */; };

--- a/BridgeSDK.xcodeproj/project.pbxproj
+++ b/BridgeSDK.xcodeproj/project.pbxproj
@@ -128,7 +128,6 @@
 		606FDE261A2F9E4300898466 /* SBBIdentifierHolder.m in Sources */ = {isa = PBXBuildFile; fileRef = 606FDE241A2F9E4300898466 /* SBBIdentifierHolder.m */; };
 		6070B1DB1DDD02CA00886FB6 /* SBBParticipantManagerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 6070B1DA1DDD02C300886FB6 /* SBBParticipantManagerInternal.h */; };
 		60737A211DA828D20078E13E /* SBBBridgeAPIManagerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 60737A201DA828D20078E13E /* SBBBridgeAPIManagerInternal.h */; };
-		607B127D1E4BCF9500237EA7 /* OpenSSL.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 607B127C1E4BCF8A00237EA7 /* OpenSSL.a */; };
 		60B635401B14ED0500C4DA63 /* SBBBridgeNetworkManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 60B6353E1B14ED0500C4DA63 /* SBBBridgeNetworkManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		60B635411B14ED0500C4DA63 /* SBBBridgeNetworkManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 60B6353F1B14ED0500C4DA63 /* SBBBridgeNetworkManager.m */; };
 		60B635431B14F5C800C4DA63 /* SBBNetworkManagerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 60B635421B14F5C800C4DA63 /* SBBNetworkManagerInternal.h */; };
@@ -304,6 +303,7 @@
 		807AE2FD1B62E98C002588BB /* SBBTaskReference.m in Sources */ = {isa = PBXBuildFile; fileRef = 807AE2F51B62E98B002588BB /* SBBTaskReference.m */; };
 		807AE2FE1B62E98C002588BB /* SBBUserSessionInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 807AE2F61B62E98C002588BB /* SBBUserSessionInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		807AE2FF1B62E98C002588BB /* SBBUserSessionInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 807AE2F71B62E98C002588BB /* SBBUserSessionInfo.m */; };
+		807D50701E9DACE600FB6F4F /* openssl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 607B127C1E4BCF8A00237EA7 /* openssl.a */; };
 		80855F5619BE258C006601C7 /* BridgeSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = 80855F5519BE258C006601C7 /* BridgeSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		80855F7119BE27ED006601C7 /* SBBErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 80855F6A19BE27ED006601C7 /* SBBErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		80855F7219BE27ED006601C7 /* SBBNetworkManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 80855F6B19BE27ED006601C7 /* SBBNetworkManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -636,8 +636,8 @@
 		606FDE241A2F9E4300898466 /* SBBIdentifierHolder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBBIdentifierHolder.m; sourceTree = "<group>"; };
 		6070B1DA1DDD02C300886FB6 /* SBBParticipantManagerInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SBBParticipantManagerInternal.h; sourceTree = "<group>"; };
 		60737A201DA828D20078E13E /* SBBBridgeAPIManagerInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SBBBridgeAPIManagerInternal.h; sourceTree = "<group>"; };
-		607B127A1E4BCE0B00237EA7 /* OpenSSL */ = {isa = PBXFileReference; lastKnownFileType = folder; path = OpenSSL; sourceTree = "<group>"; };
-		607B127C1E4BCF8A00237EA7 /* OpenSSL.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = OpenSSL.a; sourceTree = "<group>"; };
+		607B127A1E4BCE0B00237EA7 /* openssl */ = {isa = PBXFileReference; lastKnownFileType = folder; path = openssl; sourceTree = "<group>"; };
+		607B127C1E4BCF8A00237EA7 /* openssl.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = openssl.a; sourceTree = "<group>"; };
 		60B6353E1B14ED0500C4DA63 /* SBBBridgeNetworkManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SBBBridgeNetworkManager.h; sourceTree = "<group>"; };
 		60B6353F1B14ED0500C4DA63 /* SBBBridgeNetworkManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBBBridgeNetworkManager.m; sourceTree = "<group>"; };
 		60B635421B14F5C800C4DA63 /* SBBNetworkManagerInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SBBNetworkManagerInternal.h; sourceTree = "<group>"; };
@@ -1019,7 +1019,7 @@
 			files = (
 				601F7CB51D6246DC00C5FE09 /* MobileCoreServices.framework in Frameworks */,
 				8026D6A019EC46E3008942B0 /* libz.dylib in Frameworks */,
-				607B127D1E4BCF9500237EA7 /* OpenSSL.a in Frameworks */,
+				807D50701E9DACE600FB6F4F /* openssl.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1195,8 +1195,8 @@
 		8063FF901E4A9FB1001B0C3D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				607B127C1E4BCF8A00237EA7 /* OpenSSL.a */,
-				607B127A1E4BCE0B00237EA7 /* OpenSSL */,
+				607B127C1E4BCF8A00237EA7 /* openssl.a */,
+				607B127A1E4BCE0B00237EA7 /* openssl */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -2197,7 +2197,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# first copy the correct libOpenSSL.a build variant into place\nSOURCE_DIR=\"./libOpenSSLBuilds/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}/${BITCODE_GENERATION_MODE}\"\necho \"Copying contents of ${SOURCE_DIR}\"\nrm -f ./OpenSSL.a\nrm -rf ./OpenSSL\ncp -pR \"${SOURCE_DIR}/OpenSSL\" .\n\n# we have to rename the library so Xcode doesn't find implicit\n# dependencies and try to rebuild it\ncp -p \"${SOURCE_DIR}/libOpenSSL.a\" ./OpenSSL.a\n";
+			shellScript = "# first copy the correct libOpenSSL.a build variant into place\nSOURCE_DIR=\"./libOpenSSLBuilds/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}/${BITCODE_GENERATION_MODE}\"\necho \"Copying contents of ${SOURCE_DIR}\"\nrm -f ./openssl.a\nrm -rf ./openssl\ncp -pR \"${SOURCE_DIR}/OpenSSL\" ./openssl\n\n# we have to rename the library so Xcode doesn't find implicit\n# dependencies and try to rebuild it\ncp -p \"${SOURCE_DIR}/libOpenSSL.a\" ./openssl.a\n";
 		};
 		80B2C4781E3AA70E001F9FEA /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBBridgeObject.m
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBBridgeObject.m
@@ -46,6 +46,8 @@
 
 @property (nullable, nonatomic, retain) NSString* type;
 
+@property (nullable, nonatomic, retain) NSManagedObject *forwardCursorPagedResourceList;
+
 @property (nullable, nonatomic, retain) NSManagedObject *resourceList;
 
 @end

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBForwardCursorPagedResourceList.h
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBForwardCursorPagedResourceList.h
@@ -41,6 +41,20 @@
 
 @interface _SBBForwardCursorPagedResourceList : SBBBridgeObject
 
+@property (nonatomic, strong) NSNumber* hasNext;
+
+@property (nonatomic, assign) BOOL hasNextValue;
+
+@property (nonatomic, strong) NSDate* offsetBy;
+
+@property (nonatomic, strong) NSNumber* pageSize;
+
+@property (nonatomic, assign) int16_t pageSizeValue;
+
+@property (nonatomic, strong) NSDate* scheduledOnEnd;
+
+@property (nonatomic, strong) NSDate* scheduledOnStart;
+
 @property (nonatomic, strong, readonly) NSArray *items;
 
 - (void)addItemsObject:(SBBBridgeObject*)value_ settingInverse: (BOOL) setInverse;

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBForwardCursorPagedResourceList.h
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBForwardCursorPagedResourceList.h
@@ -1,5 +1,5 @@
 //
-//  _SBBScheduledActivity.h
+//  _SBBForwardCursorPagedResourceList.h
 //
 //	Copyright (c) 2014-2016 Sage Bionetworks
 //	All rights reserved.
@@ -27,40 +27,33 @@
 //	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
-// Make changes to SBBScheduledActivity.h instead.
+// Make changes to SBBForwardCursorPagedResourceList.h instead.
 //
 
 #import <Foundation/Foundation.h>
 #import "SBBBridgeObject.h"
 
-#import "SBBJSONValue.h"
+@class SBBBridgeObject;
 
-@class SBBActivity;
-
-@protocol _SBBScheduledActivity
+@protocol _SBBForwardCursorPagedResourceList
 
 @end
 
-@interface _SBBScheduledActivity : SBBBridgeObject
+@interface _SBBForwardCursorPagedResourceList : SBBBridgeObject
 
-@property (nonatomic, strong) id<SBBJSONValue> clientData;
+@property (nonatomic, strong, readonly) NSArray *items;
 
-@property (nonatomic, strong) NSDate* expiresOn;
+- (void)addItemsObject:(SBBBridgeObject*)value_ settingInverse: (BOOL) setInverse;
+- (void)addItemsObject:(SBBBridgeObject*)value_;
+- (void)removeItemsObjects;
+- (void)removeItemsObject:(SBBBridgeObject*)value_ settingInverse: (BOOL) setInverse;
+- (void)removeItemsObject:(SBBBridgeObject*)value_;
 
-@property (nonatomic, strong) NSDate* finishedOn;
-
-@property (nonatomic, strong) NSString* guid;
-
-@property (nonatomic, strong) NSNumber* persistent;
-
-@property (nonatomic, assign) BOOL persistentValue;
-
-@property (nonatomic, strong) NSDate* scheduledOn;
-
-@property (nonatomic, strong) NSDate* startedOn;
-
-@property (nonatomic, strong, readwrite) SBBActivity *activity;
-
-- (void) setActivity: (SBBActivity*) activity_ settingInverse: (BOOL) setInverse;
+- (void)insertObject:(SBBBridgeObject*)value inItemsAtIndex:(NSUInteger)idx;
+- (void)removeObjectFromItemsAtIndex:(NSUInteger)idx;
+- (void)insertItems:(NSArray *)value atIndexes:(NSIndexSet *)indexes;
+- (void)removeItemsAtIndexes:(NSIndexSet *)indexes;
+- (void)replaceObjectInItemsAtIndex:(NSUInteger)idx withObject:(SBBBridgeObject*)value;
+- (void)replaceItemsAtIndexes:(NSIndexSet *)indexes withItems:(NSArray *)values;
 
 @end

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBForwardCursorPagedResourceList.m
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBForwardCursorPagedResourceList.m
@@ -1,0 +1,325 @@
+//
+//  _SBBForwardCursorPagedResourceList.m
+//
+//	Copyright (c) 2014-2016 Sage Bionetworks
+//	All rights reserved.
+//
+//	Redistribution and use in source and binary forms, with or without
+//	modification, are permitted provided that the following conditions are met:
+//	    * Redistributions of source code must retain the above copyright
+//	      notice, this list of conditions and the following disclaimer.
+//	    * Redistributions in binary form must reproduce the above copyright
+//	      notice, this list of conditions and the following disclaimer in the
+//	      documentation and/or other materials provided with the distribution.
+//	    * Neither the name of Sage Bionetworks nor the names of BridgeSDk's
+//		  contributors may be used to endorse or promote products derived from
+//		  this software without specific prior written permission.
+//
+//	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//	ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//	WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//	DISCLAIMED. IN NO EVENT SHALL SAGE BIONETWORKS BE LIABLE FOR ANY
+//	DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//	(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//	ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//	(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// DO NOT EDIT. This file is machine-generated and constantly overwritten.
+// Make changes to SBBForwardCursorPagedResourceList.m instead.
+//
+
+#import "_SBBForwardCursorPagedResourceList.h"
+#import "_SBBForwardCursorPagedResourceListInternal.h"
+#import "ModelObjectInternal.h"
+#import "NSDate+SBBAdditions.h"
+
+#import "SBBBridgeObject.h"
+
+@interface _SBBForwardCursorPagedResourceList()
+
+// redefine relationships internally as readwrite
+
+@property (nonatomic, strong, readwrite) NSArray *items;
+
+@end
+
+// see xcdoc://?url=developer.apple.com/library/etc/redirect/xcode/ios/602958/documentation/Cocoa/Conceptual/CoreData/Articles/cdAccessorMethods.html
+@interface NSManagedObject (ForwardCursorPagedResourceList)
+
+@property (nullable, nonatomic, retain) NSString* listID__;
+
+@property (nullable, nonatomic, retain) NSOrderedSet<NSManagedObject *> *items;
+
+- (void)addItemsObject:(NSManagedObject *)value;
+- (void)removeItemsObject:(NSManagedObject *)value;
+- (void)addItems:(NSOrderedSet<NSManagedObject *> *)values;
+- (void)removeItems:(NSOrderedSet<NSManagedObject *> *)values;
+
+- (void)insertObject:(NSManagedObject *)value inItemsAtIndex:(NSUInteger)idx;
+- (void)removeObjectFromItemsAtIndex:(NSUInteger)idx;
+- (void)insertItems:(NSArray<NSManagedObject *> *)value atIndexes:(NSIndexSet *)indexes;
+- (void)removeItemsAtIndexes:(NSIndexSet *)indexes;
+- (void)replaceObjectInItemsAtIndex:(NSUInteger)idx withObject:(NSManagedObject *)value;
+- (void)replaceItemsAtIndexes:(NSIndexSet *)indexes withItems:(NSArray<NSManagedObject *> *)values;
+
+@end
+
+@implementation _SBBForwardCursorPagedResourceList
+
+- (instancetype)init
+{
+	if ((self = [super init]))
+	{
+
+	}
+
+	return self;
+}
+
+#pragma mark Scalar values
+
+#pragma mark Dictionary representation
+
+- (void)updateWithDictionaryRepresentation:(NSDictionary *)dictionary objectManager:(id<SBBObjectManagerProtocol>)objectManager
+{
+    [super updateWithDictionaryRepresentation:dictionary objectManager:objectManager];
+
+    // overwrite the old items relationship entirely rather than adding to it
+    [self removeItemsObjects];
+
+    for (id dictRepresentationForObject in [dictionary objectForKey:@"items"])
+    {
+        SBBBridgeObject *itemsObj = [objectManager objectFromBridgeJSON:dictRepresentationForObject];
+
+        [self addItemsObject:itemsObj];
+    }
+
+}
+
+- (NSDictionary *)dictionaryRepresentationFromObjectManager:(id<SBBObjectManagerProtocol>)objectManager
+{
+    NSMutableDictionary *dict = [[super dictionaryRepresentationFromObjectManager:objectManager] mutableCopy];
+
+    if ([self.items count] > 0)
+	{
+
+		NSMutableArray *itemsRepresentationsForDictionary = [NSMutableArray arrayWithCapacity:[self.items count]];
+
+		for (SBBBridgeObject *obj in self.items)
+        {
+            [itemsRepresentationsForDictionary addObject:[objectManager bridgeJSONFromObject:obj]];
+		}
+		[dict setObjectIfNotNil:itemsRepresentationsForDictionary forKey:@"items"];
+
+	}
+
+	return [dict copy];
+}
+
+- (void)awakeFromDictionaryRepresentationInit
+{
+	if (self.sourceDictionaryRepresentation == nil)
+		return; // awakeFromDictionaryRepresentationInit has been already executed on this object.
+
+	for (SBBBridgeObject *itemsObj in self.items)
+	{
+		[itemsObj awakeFromDictionaryRepresentationInit];
+	}
+
+	[super awakeFromDictionaryRepresentationInit];
+}
+
+#pragma mark Core Data cache
+
++ (NSString *)entityName
+{
+    return @"ForwardCursorPagedResourceList";
+}
+
+- (instancetype)initWithManagedObject:(NSManagedObject *)managedObject objectManager:(id<SBBObjectManagerProtocol>)objectManager cacheManager:(id<SBBCacheManagerProtocol>)cacheManager
+{
+
+    if (self = [super initWithManagedObject:managedObject objectManager:objectManager cacheManager:cacheManager]) {
+
+        self.listID__ = managedObject.listID__;
+
+		for (NSManagedObject *itemsManagedObj in managedObject.items)
+		{
+            Class objectClass = [SBBObjectManager bridgeClassFromType:itemsManagedObj.entity.name];
+            SBBBridgeObject *itemsObj = [[objectClass alloc] initWithManagedObject:itemsManagedObj objectManager:objectManager cacheManager:cacheManager];
+            if (itemsObj != nil)
+            {
+                [self addItemsObject:itemsObj];
+            }
+		}
+    }
+
+    return self;
+
+}
+
+- (NSManagedObject *)createInContext:(NSManagedObjectContext *)cacheContext withObjectManager:(id<SBBObjectManagerProtocol>)objectManager cacheManager:(id<SBBCacheManagerProtocol>)cacheManager
+{
+    NSManagedObject *managedObject = [NSEntityDescription insertNewObjectForEntityForName:@"ForwardCursorPagedResourceList" inManagedObjectContext:cacheContext];
+    [self updateManagedObject:managedObject withObjectManager:objectManager cacheManager:cacheManager];
+
+    // Calling code will handle saving these changes to cacheContext.
+
+    return managedObject;
+}
+
+- (NSManagedObject *)saveToContext:(NSManagedObjectContext *)cacheContext withObjectManager:(id<SBBObjectManagerProtocol>)objectManager cacheManager:(id<SBBCacheManagerProtocol>)cacheManager
+{
+    NSManagedObject *managedObject = [cacheManager cachedObjectForBridgeObject:self inContext:cacheContext];
+    if (managedObject) {
+        [self updateManagedObject:managedObject withObjectManager:objectManager cacheManager:cacheManager];
+    }
+
+    // Calling code will handle saving these changes to cacheContext.
+
+    return managedObject;
+}
+
+- (void)updateManagedObject:(NSManagedObject *)managedObject withObjectManager:(id<SBBObjectManagerProtocol>)objectManager cacheManager:(id<SBBCacheManagerProtocol>)cacheManager
+{
+    [super updateManagedObject:managedObject withObjectManager:objectManager cacheManager:cacheManager];
+    NSManagedObjectContext *cacheContext = managedObject.managedObjectContext;
+
+    managedObject.listID__ = ((id)self.listID__ == [NSNull null]) ? nil : self.listID__;
+
+    // first make a copy of the existing relationship collection, to iterate through while mutating original
+    NSOrderedSet *itemsCopy = [managedObject.items copy];
+
+    // now remove all items from the existing relationship
+    // to work pre-iOS 10, we have to work around this issue: http://stackoverflow.com/questions/7385439/exception-thrown-in-nsorderedset-generated-accessors
+    NSMutableOrderedSet *workingItemsSet = [managedObject mutableOrderedSetValueForKey:NSStringFromSelector(@selector(items))];
+    [workingItemsSet removeAllObjects];
+
+    // now put the "new" items, if any, into the relationship
+    if ([self.items count] > 0) {
+		for (SBBBridgeObject *obj in self.items) {
+            NSManagedObject *relMo = nil;
+            if ([obj isDirectlyCacheableWithContext:cacheContext]) {
+                // get it from the cache manager
+                relMo = [cacheManager cachedObjectForBridgeObject:obj inContext:cacheContext];
+            }
+            if (!relMo) {
+                // sub object is not directly cacheable, or not currently cached, so create it before adding
+                relMo = [obj createInContext:cacheContext withObjectManager:objectManager cacheManager:cacheManager];
+            }
+
+            [workingItemsSet addObject:relMo];
+
+        }
+	}
+
+    // now delete any objects that aren't still in the relationship
+    for (NSManagedObject *relMo in itemsCopy) {
+        if (![relMo valueForKey:@"forwardCursorPagedResourceList"]) {
+           [cacheContext deleteObject:relMo];
+        }
+    }
+
+    // ...and let go of the collection copy
+    itemsCopy = nil;
+
+    // Calling code will handle saving these changes to cacheContext.
+}
+
+#pragma mark Direct access
+
+- (void)addItemsObject:(SBBBridgeObject*)value_ settingInverse: (BOOL) setInverse
+{
+    if (self.items == nil)
+	{
+
+		self.items = [NSMutableArray array];
+
+	}
+
+	[(NSMutableArray *)self.items addObject:value_];
+
+}
+
+- (void)addItemsObject:(SBBBridgeObject*)value_
+{
+    [self addItemsObject:(SBBBridgeObject*)value_ settingInverse: YES];
+}
+
+- (void)removeItemsObjects
+{
+
+    self.items = [NSMutableArray array];
+
+}
+
+- (void)removeItemsObject:(SBBBridgeObject*)value_ settingInverse: (BOOL) setInverse
+{
+
+    [(NSMutableArray *)self.items removeObject:value_];
+
+}
+
+- (void)removeItemsObject:(SBBBridgeObject*)value_
+{
+    [self removeItemsObject:(SBBBridgeObject*)value_ settingInverse: YES];
+}
+
+- (void)insertObject:(SBBBridgeObject*)value inItemsAtIndex:(NSUInteger)idx {
+    [self insertObject:value inItemsAtIndex:idx settingInverse:YES];
+}
+
+- (void)insertObject:(SBBBridgeObject*)value inItemsAtIndex:(NSUInteger)idx settingInverse:(BOOL)setInverse {
+
+    [(NSMutableArray *)self.items insertObject:value atIndex:idx];
+
+}
+
+- (void)removeObjectFromItemsAtIndex:(NSUInteger)idx {
+    [self removeObjectFromItemsAtIndex:idx settingInverse:YES];
+}
+
+- (void)removeObjectFromItemsAtIndex:(NSUInteger)idx settingInverse:(BOOL)setInverse {
+    SBBBridgeObject *object = [self.items objectAtIndex:idx];
+    [self removeItemsObject:object settingInverse:YES];
+}
+
+- (void)insertItems:(NSArray *)value atIndexes:(NSIndexSet *)indexes {
+    [self insertItems:value atIndexes:indexes settingInverse:YES];
+}
+
+- (void)insertItems:(NSArray *)value atIndexes:(NSIndexSet *)indexes settingInverse:(BOOL)setInverse {
+    [(NSMutableArray *)self.items insertObjects:value atIndexes:indexes];
+
+}
+
+- (void)removeItemsAtIndexes:(NSIndexSet *)indexes {
+    [self removeItemsAtIndexes:indexes settingInverse:YES];
+}
+
+- (void)removeItemsAtIndexes:(NSIndexSet *)indexes settingInverse:(BOOL)setInverse {
+
+    [(NSMutableArray *)self.items removeObjectsAtIndexes:indexes];
+}
+
+- (void)replaceObjectInItemsAtIndex:(NSUInteger)idx withObject:(SBBBridgeObject*)value {
+    [self replaceObjectInItemsAtIndex:idx withObject:value settingInverse:YES];
+}
+
+- (void)replaceObjectInItemsAtIndex:(NSUInteger)idx withObject:(SBBBridgeObject*)value settingInverse:(BOOL)setInverse {
+
+    [(NSMutableArray *)self.items replaceObjectAtIndex:idx withObject:value];
+}
+
+- (void)replaceItemsAtIndexes:(NSIndexSet *)indexes withItems:(NSArray *)value {
+    [self replaceItemsAtIndexes:indexes withItems:value settingInverse:YES];
+}
+
+- (void)replaceItemsAtIndexes:(NSIndexSet *)indexes withItems:(NSArray *)value settingInverse:(BOOL)setInverse {
+
+    [(NSMutableArray *)self.items replaceObjectsAtIndexes:indexes withObjects:value];
+}
+
+@end

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBForwardCursorPagedResourceList.m
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBForwardCursorPagedResourceList.m
@@ -48,7 +48,19 @@
 // see xcdoc://?url=developer.apple.com/library/etc/redirect/xcode/ios/602958/documentation/Cocoa/Conceptual/CoreData/Articles/cdAccessorMethods.html
 @interface NSManagedObject (ForwardCursorPagedResourceList)
 
+@property (nullable, nonatomic, retain) NSNumber* hasNext;
+
+@property (nullable, nonatomic, retain) NSDate* lastOffsetBy__;
+
 @property (nullable, nonatomic, retain) NSString* listID__;
+
+@property (nullable, nonatomic, retain) NSDate* offsetBy;
+
+@property (nullable, nonatomic, retain) NSNumber* pageSize;
+
+@property (nullable, nonatomic, retain) NSDate* scheduledOnEnd;
+
+@property (nullable, nonatomic, retain) NSDate* scheduledOnStart;
 
 @property (nullable, nonatomic, retain) NSOrderedSet<NSManagedObject *> *items;
 
@@ -80,11 +92,41 @@
 
 #pragma mark Scalar values
 
+- (BOOL)hasNextValue
+{
+	return [self.hasNext boolValue];
+}
+
+- (void)setHasNextValue:(BOOL)value_
+{
+	self.hasNext = [NSNumber numberWithBool:value_];
+}
+
+- (int16_t)pageSizeValue
+{
+	return [self.pageSize shortValue];
+}
+
+- (void)setPageSizeValue:(int16_t)value_
+{
+	self.pageSize = [NSNumber numberWithShort:value_];
+}
+
 #pragma mark Dictionary representation
 
 - (void)updateWithDictionaryRepresentation:(NSDictionary *)dictionary objectManager:(id<SBBObjectManagerProtocol>)objectManager
 {
     [super updateWithDictionaryRepresentation:dictionary objectManager:objectManager];
+
+    self.hasNext = [dictionary objectForKey:@"hasNext"];
+
+    self.offsetBy = [NSDate dateWithISO8601String:[dictionary objectForKey:@"offsetBy"]];
+
+    self.pageSize = [dictionary objectForKey:@"pageSize"];
+
+    self.scheduledOnEnd = [NSDate dateWithISO8601String:[dictionary objectForKey:@"scheduledOnEnd"]];
+
+    self.scheduledOnStart = [NSDate dateWithISO8601String:[dictionary objectForKey:@"scheduledOnStart"]];
 
     // overwrite the old items relationship entirely rather than adding to it
     [self removeItemsObjects];
@@ -101,6 +143,16 @@
 - (NSDictionary *)dictionaryRepresentationFromObjectManager:(id<SBBObjectManagerProtocol>)objectManager
 {
     NSMutableDictionary *dict = [[super dictionaryRepresentationFromObjectManager:objectManager] mutableCopy];
+
+    [dict setObjectIfNotNil:self.hasNext forKey:@"hasNext"];
+
+    [dict setObjectIfNotNil:[self.offsetBy ISO8601String] forKey:@"offsetBy"];
+
+    [dict setObjectIfNotNil:self.pageSize forKey:@"pageSize"];
+
+    [dict setObjectIfNotNil:[self.scheduledOnEnd ISO8601String] forKey:@"scheduledOnEnd"];
+
+    [dict setObjectIfNotNil:[self.scheduledOnStart ISO8601String] forKey:@"scheduledOnStart"];
 
     if ([self.items count] > 0)
 	{
@@ -143,7 +195,19 @@
 
     if (self = [super initWithManagedObject:managedObject objectManager:objectManager cacheManager:cacheManager]) {
 
+        self.hasNext = managedObject.hasNext;
+
+        self.lastOffsetBy__ = managedObject.lastOffsetBy__;
+
         self.listID__ = managedObject.listID__;
+
+        self.offsetBy = managedObject.offsetBy;
+
+        self.pageSize = managedObject.pageSize;
+
+        self.scheduledOnEnd = managedObject.scheduledOnEnd;
+
+        self.scheduledOnStart = managedObject.scheduledOnStart;
 
 		for (NSManagedObject *itemsManagedObj in managedObject.items)
 		{
@@ -187,7 +251,19 @@
     [super updateManagedObject:managedObject withObjectManager:objectManager cacheManager:cacheManager];
     NSManagedObjectContext *cacheContext = managedObject.managedObjectContext;
 
+    managedObject.hasNext = ((id)self.hasNext == [NSNull null]) ? nil : self.hasNext;
+
+    managedObject.lastOffsetBy__ = ((id)self.lastOffsetBy__ == [NSNull null]) ? nil : self.lastOffsetBy__;
+
     managedObject.listID__ = ((id)self.listID__ == [NSNull null]) ? nil : self.listID__;
+
+    managedObject.offsetBy = ((id)self.offsetBy == [NSNull null]) ? nil : self.offsetBy;
+
+    managedObject.pageSize = ((id)self.pageSize == [NSNull null]) ? nil : self.pageSize;
+
+    managedObject.scheduledOnEnd = ((id)self.scheduledOnEnd == [NSNull null]) ? nil : self.scheduledOnEnd;
+
+    managedObject.scheduledOnStart = ((id)self.scheduledOnStart == [NSNull null]) ? nil : self.scheduledOnStart;
 
     // first make a copy of the existing relationship collection, to iterate through while mutating original
     NSOrderedSet *itemsCopy = [managedObject.items copy];

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBForwardCursorPagedResourceList.m
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBForwardCursorPagedResourceList.m
@@ -291,10 +291,10 @@
         }
 	}
 
-    // now delete any objects that aren't still in the relationship
+    // now release any objects that aren't still in the relationship (they will be deleted when they no longer belong to any to-many relationships)
     for (NSManagedObject *relMo in itemsCopy) {
         if (![relMo valueForKey:@"forwardCursorPagedResourceList"]) {
-           [cacheContext deleteObject:relMo];
+           [self releaseManagedObject:relMo inContext:cacheContext];
         }
     }
 

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBForwardCursorPagedResourceListInternal.h
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBForwardCursorPagedResourceListInternal.h
@@ -11,6 +11,8 @@
 
 @interface _SBBForwardCursorPagedResourceList ()
 
+@property (nonatomic, strong) NSDate* lastOffsetBy__;
+
 @property (nonatomic, strong) NSString* listID__;
 
 @end

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBForwardCursorPagedResourceListInternal.h
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBForwardCursorPagedResourceListInternal.h
@@ -1,0 +1,16 @@
+//
+//  _SBBForwardCursorPagedResourceListInternal.h
+//
+//  $Id$
+//
+// DO NOT EDIT. This file is machine-generated and constantly overwritten.
+// Make changes to SBBForwardCursorPagedResourceListInternal.h instead.
+//
+
+#import "_SBBForwardCursorPagedResourceList.h"
+
+@interface _SBBForwardCursorPagedResourceList ()
+
+@property (nonatomic, strong) NSString* listID__;
+
+@end

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBMultiValueConstraints.m
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBMultiValueConstraints.m
@@ -248,10 +248,10 @@
         }
 	}
 
-    // now delete any objects that aren't still in the relationship
+    // now release any objects that aren't still in the relationship (they will be deleted when they no longer belong to any to-many relationships)
     for (NSManagedObject *relMo in enumerationCopy) {
         if (![relMo valueForKey:@"multiValueConstraints"]) {
-           [cacheContext deleteObject:relMo];
+           [self releaseManagedObject:relMo inContext:cacheContext];
         }
     }
 

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBResourceList.m
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBResourceList.m
@@ -235,10 +235,10 @@
         }
 	}
 
-    // now delete any objects that aren't still in the relationship
+    // now release any objects that aren't still in the relationship (they will be deleted when they no longer belong to any to-many relationships)
     for (NSManagedObject *relMo in itemsCopy) {
         if (![relMo valueForKey:@"resourceList"]) {
-           [cacheContext deleteObject:relMo];
+           [self releaseManagedObject:relMo inContext:cacheContext];
         }
     }
 

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBSchedule.m
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBSchedule.m
@@ -328,10 +328,10 @@
         }
 	}
 
-    // now delete any objects that aren't still in the relationship
+    // now release any objects that aren't still in the relationship (they will be deleted when they no longer belong to any to-many relationships)
     for (NSManagedObject *relMo in activitiesCopy) {
         if (![relMo valueForKey:@"schedule"]) {
-           [cacheContext deleteObject:relMo];
+           [self releaseManagedObject:relMo inContext:cacheContext];
         }
     }
 

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBScheduledActivity.m
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBScheduledActivity.m
@@ -43,6 +43,8 @@
 // see xcdoc://?url=developer.apple.com/library/etc/redirect/xcode/ios/602958/documentation/Cocoa/Conceptual/CoreData/Articles/cdAccessorMethods.html
 @interface NSManagedObject (ScheduledActivity)
 
+@property (nullable, nonatomic, retain) id<SBBJSONValue> clientData;
+
 @property (nullable, nonatomic, retain) NSDate* expiresOn;
 
 @property (nullable, nonatomic, retain) NSDate* finishedOn;
@@ -89,6 +91,8 @@
 {
     [super updateWithDictionaryRepresentation:dictionary objectManager:objectManager];
 
+    self.clientData = [dictionary objectForKey:@"clientData"];
+
     self.expiresOn = [NSDate dateWithISO8601String:[dictionary objectForKey:@"expiresOn"]];
 
     self.finishedOn = [NSDate dateWithISO8601String:[dictionary objectForKey:@"finishedOn"]];
@@ -114,6 +118,8 @@
 - (NSDictionary *)dictionaryRepresentationFromObjectManager:(id<SBBObjectManagerProtocol>)objectManager
 {
     NSMutableDictionary *dict = [[super dictionaryRepresentationFromObjectManager:objectManager] mutableCopy];
+
+    [dict setObjectIfNotNil:self.clientData forKey:@"clientData"];
 
     [dict setObjectIfNotNil:[self.expiresOn ISO8601String] forKey:@"expiresOn"];
 
@@ -153,6 +159,8 @@
 {
 
     if (self = [super initWithManagedObject:managedObject objectManager:objectManager cacheManager:cacheManager]) {
+
+        self.clientData = managedObject.clientData;
 
         self.expiresOn = managedObject.expiresOn;
 
@@ -205,6 +213,8 @@
 {
     [super updateManagedObject:managedObject withObjectManager:objectManager cacheManager:cacheManager];
     NSManagedObjectContext *cacheContext = managedObject.managedObjectContext;
+
+    managedObject.clientData = ((id)self.clientData == [NSNull null]) ? nil : self.clientData;
 
     managedObject.expiresOn = ((id)self.expiresOn == [NSNull null]) ? nil : self.expiresOn;
 

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBSurvey.m
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBSurvey.m
@@ -339,10 +339,10 @@
         }
 	}
 
-    // now delete any objects that aren't still in the relationship
+    // now release any objects that aren't still in the relationship (they will be deleted when they no longer belong to any to-many relationships)
     for (NSManagedObject *relMo in elementsCopy) {
         if (![relMo valueForKey:@"survey"]) {
-           [cacheContext deleteObject:relMo];
+           [self releaseManagedObject:relMo inContext:cacheContext];
         }
     }
 

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBSurveyConstraints.m
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBSurveyConstraints.m
@@ -220,10 +220,10 @@
         }
 	}
 
-    // now delete any objects that aren't still in the relationship
+    // now release any objects that aren't still in the relationship (they will be deleted when they no longer belong to any to-many relationships)
     for (NSManagedObject *relMo in rulesCopy) {
         if (![relMo valueForKey:@"surveyConstraints"]) {
-           [cacheContext deleteObject:relMo];
+           [self releaseManagedObject:relMo inContext:cacheContext];
         }
     }
 

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBUserSessionInfo.m
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/MachineGeneratedDoNotEdit/_SBBUserSessionInfo.m
@@ -354,10 +354,10 @@
         }
 	}
 
-    // now delete any objects that aren't still in the relationship
+    // now release any objects that aren't still in the relationship (they will be deleted when they no longer belong to any to-many relationships)
     for (NSManagedObject *relMo in consentStatusesCopy) {
         if (![relMo valueForKey:@"userSessionInfo"]) {
-           [cacheContext deleteObject:relMo];
+           [self releaseManagedObject:relMo inContext:cacheContext];
         }
     }
 

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/SBBBridgeObject.m
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/SBBBridgeObject.m
@@ -57,4 +57,12 @@
     return [NSString stringWithFormat: @"<%@ %p> %@", NSStringFromClass([self class]), self, self.dictionaryRepresentation];
 }
 
+- (void)releaseManagedObject:(NSManagedObject *)managedObject inContext:(NSManagedObjectContext *)cacheContext
+{
+    // delete managedObject from context when no longer a member of a ResourceList or a ForwardCursorPagedResourceList
+    if (![managedObject valueForKey:@"resourceList"] && ![managedObject valueForKey:@"forwardCursorPagedResourceList"]) {
+        [cacheContext deleteObject:managedObject];
+    }
+}
+
 @end

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/SBBBridgeObjects.h
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/SBBBridgeObjects.h
@@ -8,6 +8,7 @@
 #import "SBBDateTimeConstraints.h"
 #import "SBBDecimalConstraints.h"
 #import "SBBDurationConstraints.h"
+#import "SBBForwardCursorPagedResourceList.h"
 #import "SBBIdentifierHolder.h"
 #import "SBBImage.h"
 #import "SBBIntegerConstraints.h"

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/SBBDataModel.xcdatamodeld/SBBDataModel.xcdatamodel/contents
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/SBBDataModel.xcdatamodeld/SBBDataModel.xcdatamodel/contents
@@ -95,11 +95,21 @@
         <attribute name="unit" optional="YES" attributeType="String" regularExpressionString="^(seconds|minutes|hours|days|weeks|months|years)$" syncable="YES"/>
     </entity>
     <entity name="ForwardCursorPagedResourceList" parentEntity="BridgeObject" syncable="YES">
+        <attribute name="hasNext" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastOffsetBy__" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES">
+            <userInfo>
+                <entry key="notInPONSODictionary" value="1"/>
+            </userInfo>
+        </attribute>
         <attribute name="listID__" optional="YES" attributeType="String" defaultValueString="ScheduledActivity" syncable="YES">
             <userInfo>
                 <entry key="notInPONSODictionary" value="1"/>
             </userInfo>
         </attribute>
+        <attribute name="offsetBy" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="pageSize" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="scheduledOnEnd" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="scheduledOnStart" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="BridgeObject" inverseName="forwardCursorPagedResourceList" inverseEntity="BridgeObject" syncable="YES"/>
         <userInfo>
             <entry key="entityIDKeyPath" value="listID__"/>
@@ -402,7 +412,7 @@
         <element name="DateTimeConstraints" positionX="0" positionY="0" width="128" height="90"/>
         <element name="DecimalConstraints" positionX="0" positionY="0" width="128" height="105"/>
         <element name="DurationConstraints" positionX="0" positionY="0" width="128" height="60"/>
-        <element name="ForwardCursorPagedResourceList" positionX="9" positionY="153" width="128" height="75"/>
+        <element name="ForwardCursorPagedResourceList" positionX="9" positionY="153" width="128" height="165"/>
         <element name="IdentifierHolder" positionX="0" positionY="0" width="128" height="60"/>
         <element name="Image" positionX="0" positionY="0" width="128" height="90"/>
         <element name="IntegerConstraints" positionX="0" positionY="0" width="128" height="105"/>

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/SBBDataModel.xcdatamodeld/SBBDataModelV4.xcdatamodel/contents
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/SBBDataModel.xcdatamodeld/SBBDataModelV4.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="12141" systemVersion="16E195" minimumToolsVersion="Xcode 4.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="11759" systemVersion="16D32" minimumToolsVersion="Xcode 4.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
     <entity name="Activity" parentEntity="BridgeObject" syncable="YES">
         <attribute name="activityType" optional="YES" attributeType="String" regularExpressionString="^(task|survey)$" syncable="YES"/>
         <attribute name="guid" optional="YES" attributeType="String" syncable="YES"/>
@@ -30,11 +30,6 @@
                 <entry key="mogenerator.readonly" value="YES"/>
             </userInfo>
         </attribute>
-        <relationship name="forwardCursorPagedResourceList" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ForwardCursorPagedResourceList" inverseName="items" inverseEntity="ForwardCursorPagedResourceList" syncable="YES">
-            <userInfo>
-                <entry key="notInPONSODictionary" value="1"/>
-            </userInfo>
-        </relationship>
         <relationship name="resourceList" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ResourceList" inverseName="items" inverseEntity="ResourceList" syncable="YES">
             <userInfo>
                 <entry key="notInPONSODictionary" value="1"/>
@@ -93,17 +88,6 @@
     </entity>
     <entity name="DurationConstraints" parentEntity="SurveyConstraints" syncable="YES">
         <attribute name="unit" optional="YES" attributeType="String" regularExpressionString="^(seconds|minutes|hours|days|weeks|months|years)$" syncable="YES"/>
-    </entity>
-    <entity name="ForwardCursorPagedResourceList" parentEntity="BridgeObject" syncable="YES">
-        <attribute name="listID__" optional="YES" attributeType="String" defaultValueString="ScheduledActivity" syncable="YES">
-            <userInfo>
-                <entry key="notInPONSODictionary" value="1"/>
-            </userInfo>
-        </attribute>
-        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="BridgeObject" inverseName="forwardCursorPagedResourceList" inverseEntity="BridgeObject" syncable="YES"/>
-        <userInfo>
-            <entry key="entityIDKeyPath" value="listID__"/>
-        </userInfo>
     </entity>
     <entity name="IdentifierHolder" parentEntity="BridgeObject" syncable="YES">
         <attribute name="identifier" optional="YES" attributeType="String" syncable="YES"/>
@@ -169,11 +153,6 @@
         </userInfo>
     </entity>
     <entity name="ScheduledActivity" parentEntity="BridgeObject" syncable="YES">
-        <attribute name="clientData" optional="YES" attributeType="Transformable" syncable="YES">
-            <userInfo>
-                <entry key="attributeValueClassName" value="id&lt;SBBJSONValue&gt;"/>
-            </userInfo>
-        </attribute>
         <attribute name="expiresOn" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="finishedOn" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="guid" optional="YES" attributeType="String" syncable="YES"/>
@@ -182,7 +161,6 @@
         <attribute name="startedOn" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <relationship name="activity" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Activity" inverseName="scheduledActivity" inverseEntity="Activity" syncable="YES"/>
         <userInfo>
-            <entry key="additionalHeaderFileName" value="SBBJSONValue.h"/>
             <entry key="entityIDKeyPath" value="guid"/>
             <entry key="hasClientWritableFields" value="1"/>
         </userInfo>
@@ -394,7 +372,7 @@
     <elements>
         <element name="Activity" positionX="0" positionY="0" width="128" height="165"/>
         <element name="BooleanConstraints" positionX="0" positionY="0" width="128" height="45"/>
-        <element name="BridgeObject" positionX="0" positionY="0" width="128" height="105"/>
+        <element name="BridgeObject" positionX="0" positionY="0" width="128" height="60"/>
         <element name="ConsentSignature" positionX="9" positionY="99" width="128" height="120"/>
         <element name="ConsentStatus" positionX="0" positionY="90" width="128" height="135"/>
         <element name="DataGroups" positionX="0" positionY="90" width="128" height="60"/>
@@ -402,14 +380,13 @@
         <element name="DateTimeConstraints" positionX="0" positionY="0" width="128" height="90"/>
         <element name="DecimalConstraints" positionX="0" positionY="0" width="128" height="105"/>
         <element name="DurationConstraints" positionX="0" positionY="0" width="128" height="60"/>
-        <element name="ForwardCursorPagedResourceList" positionX="9" positionY="153" width="128" height="75"/>
         <element name="IdentifierHolder" positionX="0" positionY="0" width="128" height="60"/>
         <element name="Image" positionX="0" positionY="0" width="128" height="90"/>
         <element name="IntegerConstraints" positionX="0" positionY="0" width="128" height="105"/>
         <element name="MultiValueConstraints" positionX="0" positionY="0" width="128" height="90"/>
         <element name="ResourceList" positionX="0" positionY="0" width="128" height="90"/>
         <element name="Schedule" positionX="0" positionY="0" width="128" height="225"/>
-        <element name="ScheduledActivity" positionX="0" positionY="0" width="128" height="165"/>
+        <element name="ScheduledActivity" positionX="0" positionY="0" width="128" height="150"/>
         <element name="StringConstraints" positionX="0" positionY="0" width="128" height="120"/>
         <element name="StudyParticipant" positionX="18" positionY="108" width="128" height="270"/>
         <element name="Survey" positionX="0" positionY="0" width="128" height="180"/>

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/SBBForwardCursorPagedResourceList.h
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/SBBForwardCursorPagedResourceList.h
@@ -1,5 +1,5 @@
 //
-//  _SBBScheduledActivity.h
+//  SBBForwardCursorPagedResourceList.h
 //
 //	Copyright (c) 2014-2016 Sage Bionetworks
 //	All rights reserved.
@@ -26,41 +26,9 @@
 //	(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 //	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// DO NOT EDIT. This file is machine-generated and constantly overwritten.
-// Make changes to SBBScheduledActivity.h instead.
-//
 
-#import <Foundation/Foundation.h>
-#import "SBBBridgeObject.h"
+#import "_SBBForwardCursorPagedResourceList.h"
 
-#import "SBBJSONValue.h"
-
-@class SBBActivity;
-
-@protocol _SBBScheduledActivity
-
-@end
-
-@interface _SBBScheduledActivity : SBBBridgeObject
-
-@property (nonatomic, strong) id<SBBJSONValue> clientData;
-
-@property (nonatomic, strong) NSDate* expiresOn;
-
-@property (nonatomic, strong) NSDate* finishedOn;
-
-@property (nonatomic, strong) NSString* guid;
-
-@property (nonatomic, strong) NSNumber* persistent;
-
-@property (nonatomic, assign) BOOL persistentValue;
-
-@property (nonatomic, strong) NSDate* scheduledOn;
-
-@property (nonatomic, strong) NSDate* startedOn;
-
-@property (nonatomic, strong, readwrite) SBBActivity *activity;
-
-- (void) setActivity: (SBBActivity*) activity_ settingInverse: (BOOL) setInverse;
-
+@interface SBBForwardCursorPagedResourceList : _SBBForwardCursorPagedResourceList <_SBBForwardCursorPagedResourceList>
+// Custom logic goes here.
 @end

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/SBBForwardCursorPagedResourceList.m
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/SBBForwardCursorPagedResourceList.m
@@ -1,5 +1,5 @@
 //
-//  _SBBScheduledActivity.h
+//  SBBForwardCursorPagedResourceList.m
 //
 //	Copyright (c) 2014-2016 Sage Bionetworks
 //	All rights reserved.
@@ -26,41 +26,13 @@
 //	(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 //	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// DO NOT EDIT. This file is machine-generated and constantly overwritten.
-// Make changes to SBBScheduledActivity.h instead.
-//
 
-#import <Foundation/Foundation.h>
-#import "SBBBridgeObject.h"
+#import "SBBForwardCursorPagedResourceList.h"
 
-#import "SBBJSONValue.h"
+@implementation SBBForwardCursorPagedResourceList
 
-@class SBBActivity;
+#pragma mark Abstract method overrides
 
-@protocol _SBBScheduledActivity
-
-@end
-
-@interface _SBBScheduledActivity : SBBBridgeObject
-
-@property (nonatomic, strong) id<SBBJSONValue> clientData;
-
-@property (nonatomic, strong) NSDate* expiresOn;
-
-@property (nonatomic, strong) NSDate* finishedOn;
-
-@property (nonatomic, strong) NSString* guid;
-
-@property (nonatomic, strong) NSNumber* persistent;
-
-@property (nonatomic, assign) BOOL persistentValue;
-
-@property (nonatomic, strong) NSDate* scheduledOn;
-
-@property (nonatomic, strong) NSDate* startedOn;
-
-@property (nonatomic, strong, readwrite) SBBActivity *activity;
-
-- (void) setActivity: (SBBActivity*) activity_ settingInverse: (BOOL) setInverse;
+// Custom logic goes here.
 
 @end

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/SBBForwardCursorPagedResourceListInternal.h
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/SBBForwardCursorPagedResourceListInternal.h
@@ -1,0 +1,7 @@
+//
+//  SBBForwardCursorPagedResourceListInternal.h
+//	
+//  $Id$
+//
+
+#import "_SBBForwardCursorPagedResourceListInternal.h"

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/SBBScheduledActivity.m
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/SBBScheduledActivity.m
@@ -86,4 +86,9 @@ NSString * const SBBScheduledActivityStatusStringDeleted = @"deleted";
     return stringsForStatuses[[self statusEnum]];
 }
 
+- (BOOL)validateClientData:(id<SBBJSONValue> *)clientData error:(NSError **)error
+{
+    return [*clientData validateJSONWithError:error];
+}
+
 @end

--- a/BridgeSDK/BridgeAPI/BridgeAPITypes/SBBScheduledActivity.m
+++ b/BridgeSDK/BridgeAPI/BridgeAPITypes/SBBScheduledActivity.m
@@ -28,6 +28,7 @@
 //
 
 #import "SBBScheduledActivity.h"
+#import "ModelObjectInternal.h"
 
 NSString * const SBBScheduledActivityStatusStringScheduled = @"scheduled";
 NSString * const SBBScheduledActivityStatusStringAvailable = @"available";
@@ -89,6 +90,29 @@ NSString * const SBBScheduledActivityStatusStringDeleted = @"deleted";
 - (BOOL)validateClientData:(id<SBBJSONValue> *)clientData error:(NSError **)error
 {
     return [*clientData validateJSONWithError:error];
+}
+
+- (void)reconcileWithDictionaryRepresentation:(NSDictionary *)dictionary objectManager:(id<SBBObjectManagerInternalProtocol>)objectManager
+{
+    // For all but the client-writable fields, the server value is completely canonical.
+    // For the client-writable fields, the server value is canonical unless it is nil.
+    NSDate *savedStartedOn = self.startedOn;
+    NSDate *savedFinishedOn = self.finishedOn;
+    id<SBBJSONValue> savedClientData = self.clientData;
+    
+    [self updateWithDictionaryRepresentation:dictionary objectManager:objectManager];
+    
+    if (!self.startedOn) {
+        self.startedOn = savedStartedOn;
+    }
+    
+    if (!self.finishedOn) {
+        self.finishedOn = savedFinishedOn;
+    }
+    
+    if (!self.clientData) {
+        self.clientData = savedClientData;
+    }
 }
 
 @end

--- a/BridgeSDK/BridgeAPI/Categories/NSDate+SBBAdditions.h
+++ b/BridgeSDK/BridgeAPI/Categories/NSDate+SBBAdditions.h
@@ -44,6 +44,7 @@
 - (NSString *)ISO8601StringUTC;
 - (NSString *)ISO8601DateOnlyString;
 - (NSString *)ISO8601TimeOnlyString;
+- (NSString *)ISO8601DateTimeOnlyString;
 - (NSString *)ISO8601OffsetString;
 
 @end

--- a/BridgeSDK/BridgeAPI/Categories/NSDate+SBBAdditions.m
+++ b/BridgeSDK/BridgeAPI/Categories/NSDate+SBBAdditions.m
@@ -123,6 +123,13 @@
     return [[[self class] ISO8601TimeOnlyformatter] stringFromDate:self];
 }
 
+- (NSString *)ISO8601DateTimeOnlyString
+{
+    NSString *dateOnly = [self ISO8601DateOnlyString];
+    NSString *timeOnly = [self ISO8601TimeOnlyString];
+    return [NSString stringWithFormat:@"%@T%@", dateOnly, timeOnly];
+}
+
 - (NSString *)ISO8601OffsetString
 {
     return [[[self class] ISO8601OffsetOnlyformatter] stringFromDate:self];

--- a/BridgeSDK/BridgeAPI/Categories/NSDate+SBBAdditions.m
+++ b/BridgeSDK/BridgeAPI/Categories/NSDate+SBBAdditions.m
@@ -89,7 +89,7 @@
     static NSDateFormatter *formatter;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        formatter = [[self ISO8601UTCformatter] copy];
+        formatter = [[self ISO8601formatter] copy];
         [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSS"];
     });
     

--- a/BridgeSDK/BridgeAPI/Categories/NSDate+SBBAdditions.m
+++ b/BridgeSDK/BridgeAPI/Categories/NSDate+SBBAdditions.m
@@ -36,16 +36,16 @@
 
 + (NSDateFormatter *)ISO8601formatter
 {
-  static NSDateFormatter *formatter;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    formatter = [[NSDateFormatter alloc] init];
-    [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"];
-    NSLocale *enUSPOSIXLocale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
-    [formatter setLocale:enUSPOSIXLocale];
-  });
-  
-  return formatter;
+    static NSDateFormatter *formatter;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        formatter = [[NSDateFormatter alloc] init];
+        [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"];
+        NSLocale *enUSPOSIXLocale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
+        [formatter setLocale:enUSPOSIXLocale];
+    });
+    
+    return formatter;
 }
 
 + (NSDateFormatter *)ISO8601UTCformatter
@@ -84,6 +84,18 @@
     return formatter;
 }
 
++ (NSDateFormatter *)ISO8601DateTimeOnlyformatter
+{
+    static NSDateFormatter *formatter;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        formatter = [[self ISO8601UTCformatter] copy];
+        [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSS"];
+    });
+    
+    return formatter;
+}
+
 + (NSDateFormatter *)ISO8601OffsetOnlyformatter
 {
     static NSDateFormatter *formatter;
@@ -100,17 +112,26 @@
 
 + (instancetype)dateWithISO8601String:(NSString *)iso8601string
 {
-  return [[self ISO8601formatter] dateFromString:iso8601string];
+    NSDate *date = [[self ISO8601formatter] dateFromString:iso8601string];
+    // check for missing TZ specifier
+    if (!date) {
+        date = [[self ISO8601DateTimeOnlyformatter] dateFromString:iso8601string];
+    }
+    // check for missing time of day entirely
+    if (!date) {
+        date = [[self ISO8601DateOnlyformatter] dateFromString:iso8601string];
+    }
+  return date;
 }
 
 - (NSString *)ISO8601String
 {
-  return [[[self class] ISO8601formatter] stringFromDate:self];
+    return [[[self class] ISO8601formatter] stringFromDate:self];
 }
 
 - (NSString *)ISO8601StringUTC
 {
-  return [[[self class] ISO8601UTCformatter] stringFromDate:self];
+    return [[[self class] ISO8601UTCformatter] stringFromDate:self];
 }
 
 - (NSString *)ISO8601DateOnlyString
@@ -125,9 +146,7 @@
 
 - (NSString *)ISO8601DateTimeOnlyString
 {
-    NSString *dateOnly = [self ISO8601DateOnlyString];
-    NSString *timeOnly = [self ISO8601TimeOnlyString];
-    return [NSString stringWithFormat:@"%@T%@", dateOnly, timeOnly];
+    return [[[self class] ISO8601DateTimeOnlyformatter] stringFromDate:self];
 }
 
 - (NSString *)ISO8601OffsetString

--- a/BridgeSDK/BridgeAPI/SBBActivityManager.h
+++ b/BridgeSDK/BridgeAPI/SBBActivityManager.h
@@ -128,13 +128,13 @@ typedef void (^SBBActivityManagerUpdateCompletionBlock)(_Nullable id responseObj
  
  The data can be of any JSON-serializable iOS type: NSString, NSNumber, NSNull, or an NSArray or NSDictionary containing only values of a JSON-serializable iOS type or collection thereof (and the keys of the NSDictionary must be of type NSString).
  
- @param clientData          A (relatively small) JSON-serializable object to store in Bridge with the ScheduledActivity.
+ @param clientData          A (relatively small) JSON-serializable object to store in Bridge with the ScheduledActivity. To set to nil, pass [NSNull null].
  @param scheduledActivity   The ScheduledActivity to which the clientData will be attached.
  @param completion          An SBBActivityManagerGetCompletionBlock to be called upon completion. Optional.
  
  @return An NSURLSessionTask object so you can cancel or suspend/resume the request.
  */
-- (NSURLSessionTask *)setClientData:(nullable id<SBBJSONValue>)clientData forScheduledActivity:(SBBScheduledActivity *)scheduledActivity withCompletion:(nullable SBBActivityManagerUpdateCompletionBlock)completion;
+- (NSURLSessionTask *)setClientData:(nonnull id<SBBJSONValue>)clientData forScheduledActivity:(SBBScheduledActivity *)scheduledActivity withCompletion:(nullable SBBActivityManagerUpdateCompletionBlock)completion;
 
 /*!
  Update multiple scheduled activities' statuses with the API at one time.

--- a/BridgeSDK/BridgeAPI/SBBActivityManager.h
+++ b/BridgeSDK/BridgeAPI/SBBActivityManager.h
@@ -57,10 +57,10 @@ typedef void (^SBBActivityManagerUpdateCompletionBlock)(id responseObject, NSErr
 /*!
  Gets all available, started, or scheduled activities for a user. The "daysAhead" parameter allows you to retrieve activities that are scheduled in the future for the indicated number of days past today (to a maximum of four days, at this time). This allows certain kinds of UIs (e.g. "You have N activities tomorrow" or "You have completed N of X activities today", even when the activities are not yet to be performed). A "daysBehind" parameter allows you to retain previously-cached activities that have not yet been completed that expired within the indicated number of days in the past. This allows UIs that say, e.g., "You left N activities uncompleted yesterday." Scheduled activities will be returned in the timezone of the device at the time of the request. Once a task is finished, or expires (the time has passed for it to be started), or becomes invalid due to a schedule change on the server, it will be removed from the list of scheduled activities returned from Bridge, and (except for previously-fetched but unfinished tasks within daysBehind) will also be removed from the list passed to this method's completion handler.
   
- @param daysAhead  A number of days in the future (0-4) for which to retrieve available/started/scheduled activities.
+ @param daysAhead   A number of days in the future (0-4) for which to retrieve available/started/scheduled activities.
  @param daysBehind  A number of days in the past (no limit) for which to include previously-cached but expired and unfinished activities (ignored if the SDK was initialized with useCache=NO).
- @param policy Caching policy to use (ignored if the SDK was initialized with useCache=NO).
- @param completion An SBBActivityManagerGetCompletionBlock to be called upon completion.
+ @param policy      Caching policy to use (ignored if the SDK was initialized with useCache=NO).
+ @param completion  An SBBActivityManagerGetCompletionBlock to be called upon completion.
  
  @return An NSURLSessionTask object so you can cancel or suspend/resume the request.
  */
@@ -120,9 +120,24 @@ typedef void (^SBBActivityManagerUpdateCompletionBlock)(id responseObject, NSErr
 - (NSURLSessionTask *)deleteScheduledActivity:(SBBScheduledActivity *)scheduledActivity withCompletion:(SBBActivityManagerUpdateCompletionBlock)completion;
 
 /*!
+ Add client-specific JSON-serializable data to a ScheduledActivity.
+ 
+ This data will be stored on this ScheduledActivity object on the Bridge server, for later retrieval via the getScheduledActivitiesForGuid:scheduledFrom:to:withCompletion: method. This is intended to allow storing small amounts of data summarizing the result of performing the activity, e.g. a single computed "score" or the like, and not the full raw results.
+ 
+ The data can be of any JSON-serializable iOS type: NSString, NSNumber, NSNull, or an NSArray or NSDictionary containing only values of a JSON-serializable iOS type or collection thereof (and the keys of the NSDictionary must be of type NSString).
+ 
+ @param clientData          A (relatively small) JSON-serializable object to store in Bridge with the ScheduledActivity.
+ @param scheduledActivity   The ScheduledActivity to which the clientData will be attached.
+ @param completion          An SBBActivityManagerGetCompletionBlock to be called upon completion.
+ 
+ @return An NSURLSessionTask object so you can cancel or suspend/resume the request.
+ */
+- (NSURLSessionTask *)setClientData:(id<SBBJSONValue>)clientData forScheduledActivity:(SBBScheduledActivity *)scheduledActivity withCompletion:(SBBActivityManagerUpdateCompletionBlock)completion;
+
+/*!
  Update multiple scheduled activities' statuses with the API at one time.
  
- Only the startedOn and finishedOn fields of ScheduledActivity are user-writable, so only changes to those fields will have any effect on the server state.
+ Only the startedOn, finishedOn, and clientData fields of ScheduledActivity are user-writable, so only changes to those fields will have any effect on the server state.
  
  @param scheduledActivities The list of ScheduledActivity objects whose statuses are to be updated to the API.
  @param completion An SBBActivityManagerUpdateCompletionBlock to be called upon completion.
@@ -130,6 +145,19 @@ typedef void (^SBBActivityManagerUpdateCompletionBlock)(id responseObject, NSErr
  @return An NSURLSessionTask object so you can cancel or suspend/resume the request.
  */
 - (NSURLSessionTask *)updateScheduledActivities:(NSArray *)scheduledActivities withCompletion:(SBBActivityManagerUpdateCompletionBlock)completion;
+
+/*!
+ Gets all the participant's activities with the specified guid in the specified date range. Activities that were never scheduled (e.g. the participant didn't open the app for longer than the cacheDaysAhead that was given when setting up BridgeSDK, so it didn't request scheduled activities during that period, so Bridge never scheduled them) will not be included as they don't actually exist on the server.
+ 
+ @param activityGuid    The guid for the desired activities to be retrieved. This can be found in the Bridge study manager UI next to the activity's entry in its schedule.
+ @param scheduledFrom   The earlier end of the desired date range for activities to be retrieved.
+ @param scheduledTo     The later end of the desired date range for activities to be retrieved.
+ @param policy          Caching policy to use (ignored if the SDK was initialized with useCache=NO).
+ @param completion      An SBBActivityManagerGetCompletionBlock to be called upon completion.
+ 
+ @return An NSURLSessionTask object so you can cancel or suspend/resume the request.
+ */
+- (NSURLSessionTask *)getScheduledActivitiesForGuid:(NSString *)activityGuid scheduledFrom:(NSDate *)scheduledFrom to:(NSDate *)scheduledTo cachingPolicy:(SBBCachingPolicy)policy withCompletion:(SBBActivityManagerGetCompletionBlock)completion;
 
 @end
 

--- a/BridgeSDK/BridgeAPI/SBBActivityManager.h
+++ b/BridgeSDK/BridgeAPI/SBBActivityManager.h
@@ -32,13 +32,15 @@
 #import "SBBBridgeAPIManager.h"
 #import "SBBScheduledActivity.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*!
  Completion block called when retrieving scheduled activities from the API.
  
  @param activitiesList By default, an array of SBBScheduledActivity objects, unless the ScheduledActivity type has been mapped in SBBObjectManager setupMappingForType:toClass:fieldToPropertyMappings:.
  @param error       An error that occurred during execution of the method for which this is a completion block, or nil.
  */
-typedef void (^SBBActivityManagerGetCompletionBlock)(NSArray *activitiesList, NSError *error);
+typedef void (^SBBActivityManagerGetCompletionBlock)(NSArray * _Nullable activitiesList, NSError * _Nullable error);
 
 /*!
  Completion block called when updating a ScheduledActivity's status to the API.
@@ -46,7 +48,7 @@ typedef void (^SBBActivityManagerGetCompletionBlock)(NSArray *activitiesList, NS
  @param responseObject JSON response from the server.
  @param error          An error that occurred during execution of the method for which this is a completion block, or nil.
  */
-typedef void (^SBBActivityManagerUpdateCompletionBlock)(id responseObject, NSError *error);
+typedef void (^SBBActivityManagerUpdateCompletionBlock)(_Nullable id responseObject, NSError * _Nullable error);
 
 /*!
  This protocol defines the interface to the SBBActivityManager's non-constructor, non-initializer methods. The interface is
@@ -72,7 +74,7 @@ typedef void (^SBBActivityManagerUpdateCompletionBlock)(id responseObject, NSErr
 - (NSURLSessionTask *)getScheduledActivitiesForDaysAhead:(NSInteger)daysAhead cachingPolicy:(SBBCachingPolicy)policy withCompletion:(SBBActivityManagerGetCompletionBlock)completion;
 
 /**
- This is a convenience method that assumes the default caching policy, which is SBBCachingPolicyFallBackToCache,
+ This is a convenience method that assumes the default caching policy, which is SBBCachingPolicyFallBackToCached,
  if caching is enabled. Also implies a default value of 1 for daysBehind.
  */
 - (NSURLSessionTask *)getScheduledActivitiesForDaysAhead:(NSInteger)daysAhead withCompletion:(SBBActivityManagerGetCompletionBlock)completion;
@@ -84,11 +86,11 @@ typedef void (^SBBActivityManagerUpdateCompletionBlock)(id responseObject, NSErr
  
  @param scheduledActivity   The ScheduledActivity to be marked as started.
  @param startDate           The date/time as of which the Task was started.
- @param completion          An SBBActivityManagerUpdateCompletionBlock to be called upon completion.
+ @param completion          An SBBActivityManagerUpdateCompletionBlock to be called upon completion. Optional.
  
  @return An NSURLSessionTask object so you can cancel or suspend/resume the request.
  */
-- (NSURLSessionTask *)startScheduledActivity:(SBBScheduledActivity *)scheduledActivity asOf:(NSDate *)startDate withCompletion:(SBBActivityManagerUpdateCompletionBlock)completion;
+- (NSURLSessionTask *)startScheduledActivity:(SBBScheduledActivity *)scheduledActivity asOf:(NSDate *)startDate withCompletion:(nullable SBBActivityManagerUpdateCompletionBlock)completion;
 
 /*!
  Mark a ScheduledActivity as finished, as of the time this method is called.
@@ -99,11 +101,11 @@ typedef void (^SBBActivityManagerUpdateCompletionBlock)(id responseObject, NSErr
  
  @param scheduledActivity   The ScheduledActivity to be marked as started.
  @param finishDate          The date/time as of which the Task was finished.
- @param completion          An SBBActivityManagerUpdateCompletionBlock to be called upon completion.
+ @param completion          An SBBActivityManagerUpdateCompletionBlock to be called upon completion. Optional.
  
  @return An NSURLSessionTask object so you can cancel or suspend/resume the request.
  */
-- (NSURLSessionTask *)finishScheduledActivity:(SBBScheduledActivity *)scheduledActivity asOf:(NSDate *)finishDate withCompletion:(SBBActivityManagerUpdateCompletionBlock)completion;
+- (NSURLSessionTask *)finishScheduledActivity:(SBBScheduledActivity *)scheduledActivity asOf:(NSDate *)finishDate withCompletion:(nullable SBBActivityManagerUpdateCompletionBlock)completion;
 
 /*!
  Delete a ScheduledActivity from the list of available/started/scheduled activities.
@@ -113,11 +115,11 @@ typedef void (^SBBActivityManagerUpdateCompletionBlock)(id responseObject, NSErr
  This method notifies the server API to delete the scheduled activity, and calls the completion block upon success (or failure) of that notification.
  
  @param scheduledActivity   The ScheduledActivity to be deleted.
- @param completion          An SBBActivityManagerUpdateCompletionBlock to be called upon completion.
+ @param completion          An SBBActivityManagerUpdateCompletionBlock to be called upon completion. Optional.
  
  @return An NSURLSessionTask object so you can cancel or suspend/resume the request.
  */
-- (NSURLSessionTask *)deleteScheduledActivity:(SBBScheduledActivity *)scheduledActivity withCompletion:(SBBActivityManagerUpdateCompletionBlock)completion;
+- (NSURLSessionTask *)deleteScheduledActivity:(SBBScheduledActivity *)scheduledActivity withCompletion:(nullable SBBActivityManagerUpdateCompletionBlock)completion;
 
 /*!
  Add client-specific JSON-serializable data to a ScheduledActivity.
@@ -128,11 +130,11 @@ typedef void (^SBBActivityManagerUpdateCompletionBlock)(id responseObject, NSErr
  
  @param clientData          A (relatively small) JSON-serializable object to store in Bridge with the ScheduledActivity.
  @param scheduledActivity   The ScheduledActivity to which the clientData will be attached.
- @param completion          An SBBActivityManagerGetCompletionBlock to be called upon completion.
+ @param completion          An SBBActivityManagerGetCompletionBlock to be called upon completion. Optional.
  
  @return An NSURLSessionTask object so you can cancel or suspend/resume the request.
  */
-- (NSURLSessionTask *)setClientData:(id<SBBJSONValue>)clientData forScheduledActivity:(SBBScheduledActivity *)scheduledActivity withCompletion:(SBBActivityManagerUpdateCompletionBlock)completion;
+- (NSURLSessionTask *)setClientData:(nullable id<SBBJSONValue>)clientData forScheduledActivity:(SBBScheduledActivity *)scheduledActivity withCompletion:(nullable SBBActivityManagerUpdateCompletionBlock)completion;
 
 /*!
  Update multiple scheduled activities' statuses with the API at one time.
@@ -140,11 +142,11 @@ typedef void (^SBBActivityManagerUpdateCompletionBlock)(id responseObject, NSErr
  Only the startedOn, finishedOn, and clientData fields of ScheduledActivity are user-writable, so only changes to those fields will have any effect on the server state.
  
  @param scheduledActivities The list of ScheduledActivity objects whose statuses are to be updated to the API.
- @param completion An SBBActivityManagerUpdateCompletionBlock to be called upon completion.
+ @param completion An SBBActivityManagerUpdateCompletionBlock to be called upon completion. Optional.
  
  @return An NSURLSessionTask object so you can cancel or suspend/resume the request.
  */
-- (NSURLSessionTask *)updateScheduledActivities:(NSArray *)scheduledActivities withCompletion:(SBBActivityManagerUpdateCompletionBlock)completion;
+- (NSURLSessionTask *)updateScheduledActivities:(NSArray *)scheduledActivities withCompletion:(nullable SBBActivityManagerUpdateCompletionBlock)completion;
 
 /*!
  Gets all the participant's activities with the specified guid in the specified date range. Activities that were never scheduled (e.g. the participant didn't open the app for longer than the cacheDaysAhead that was given when setting up BridgeSDK, so it didn't request scheduled activities during that period, so Bridge never scheduled them) will not be included as they don't actually exist on the server.
@@ -159,6 +161,11 @@ typedef void (^SBBActivityManagerUpdateCompletionBlock)(id responseObject, NSErr
  */
 - (NSURLSessionTask *)getScheduledActivitiesForGuid:(NSString *)activityGuid scheduledFrom:(NSDate *)scheduledFrom to:(NSDate *)scheduledTo cachingPolicy:(SBBCachingPolicy)policy withCompletion:(SBBActivityManagerGetCompletionBlock)completion;
 
+/*!
+ This is a convenience method that assumes the default caching policy, which is SBBCachingPolicyFallBackToCached, if caching is enabled.
+ */
+- (NSURLSessionTask *)getScheduledActivitiesForGuid:(NSString *)activityGuid scheduledFrom:(NSDate *)scheduledFrom to:(NSDate *)scheduledTo withCompletion:(SBBActivityManagerGetCompletionBlock)completion;
+
 @end
 
 /*!
@@ -167,3 +174,5 @@ typedef void (^SBBActivityManagerUpdateCompletionBlock)(id responseObject, NSErr
 @interface SBBActivityManager : SBBBridgeAPIManager<SBBComponent, SBBActivityManagerProtocol>
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/BridgeSDK/BridgeAPI/SBBActivityManager.m
+++ b/BridgeSDK/BridgeAPI/SBBActivityManager.m
@@ -40,12 +40,16 @@
 #import "BridgeSDK+Internal.h"
 #import "SBBBridgeInfo.h"
 #import "ModelObjectInternal.h"
+#import "SBBResourceListInternal.h"
+#import "SBBForwardCursorPagedResourceListInternal.h"
 
 #define ACTIVITY_API GLOBAL_API_PREFIX @"/activities"
 
 NSString * const kSBBActivityAPI =       ACTIVITY_API;
+NSString * const kSBBHistoricalActivityAPIFormat = ACTIVITY_API @"/%@";
 NSTimeInterval const kSBB24Hours =       86400;
 NSInteger const     kMaxAdvance  =       4; // server only supports 4 days ahead
+NSInteger const     kFetchPageSize =     100;
 
 @interface SBBActivityManager()<SBBActivityManagerInternalProtocol, SBBBridgeAPIManagerInternalProtocol>
 
@@ -108,6 +112,16 @@ NSInteger const     kMaxAdvance  =       4; // server only supports 4 days ahead
     return filtered;
 }
 
+- (NSArray *)filterTasks:(NSArray *)tasks scheduledFrom:(NSDate *)startDate to:(NSDate *)endDate
+{
+    NSString *comparisonKey = NSStringFromSelector(@selector(scheduledOn));
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K >= %@ AND %K < %@",
+                              comparisonKey, startDate,
+                              comparisonKey, endDate];
+    
+    return [tasks filteredArrayUsingPredicate:predicate];
+}
+
 - (void)mapSubObjectsInTaskList:(NSMutableArray *)taskList
 {
     if ([self.objectManager conformsToProtocol:@protocol(SBBObjectManagerInternalProtocol)]) {
@@ -122,7 +136,7 @@ NSInteger const     kMaxAdvance  =       4; // server only supports 4 days ahead
 // all three have been called!
 - (SBBResourceList *)cachedTasksFromCacheManager:(id<SBBCacheManagerProtocol>)cacheManager
 {
-    SBBResourceList *tasks = (SBBResourceList *)[cacheManager cachedObjectOfType:@"ResourceList" withId:[self listIdentifier] createIfMissing:NO];
+    SBBResourceList *tasks = (SBBResourceList *)[cacheManager cachedObjectOfType:[SBBResourceList entityName] withId:[self listIdentifier] createIfMissing:NO];
     
     return tasks;
 }
@@ -299,14 +313,128 @@ NSInteger const     kMaxAdvance  =       4; // server only supports 4 days ahead
     }];
 }
 
+// pass in an initialized NSMutableArray in accumulatedItems either if not caching, or ignoring cache
+- (NSURLSessionTask *)fetchHistoricalActivitiesForGuid:(NSString *)activityGuid withParameters:(NSDictionary *)parameters offsetBy:(NSDate *)offsetBy accumulatedItems:(NSMutableArray *)accumulatedItems completion:(SBBActivityManagerGetCompletionBlock)completion
+{
+    if (offsetBy) {
+        NSString *offsetString = [offsetBy ISO8601DateTimeOnlyString];
+        NSMutableDictionary *parametersWithOffset = [parameters mutableCopy];
+        parametersWithOffset[NSStringFromSelector(@selector(offsetBy))] = offsetString;
+        parameters = [parametersWithOffset copy];
+    }
+    
+    NSMutableDictionary *headers = [NSMutableDictionary dictionary];
+    [self.authManager addAuthHeaderToHeaders:headers];
+    NSString *endpoint = [NSString stringWithFormat:kSBBHistoricalActivityAPIFormat, activityGuid];
+    
+    return [self.networkManager get:endpoint headers:headers parameters:parameters completion:^(NSURLSessionTask *task, id responseObject, NSError *error) {
+        if (error) {
+            if (gSBBUseCache) {
+                // clear lastOffsetBy__ for the next time we fetch this activity's history
+                SBBForwardCursorPagedResourceList *list = [self cachedListForActivityGuid:activityGuid];
+                list.lastOffsetBy__ = nil;
+                [list saveToCoreDataCacheWithObjectManager:self.objectManager];
+            }
+            if (completion) {
+                completion(responseObject, error);
+            }
+        } else {
+            NSDictionary *objectJSON = responseObject;
+            if (gSBBUseCache) {
+                // first, set an identifier in the JSON so we can find the cached object later--since
+                // ForwardCursorPagedResourceList doesn't come with anything by which to distinguish one
+                // from another if the items[] list is empty.
+                NSMutableDictionary *objectWithActivityGuid = [responseObject mutableCopy];
+                
+                // -- get the identifier key path we need to set from the cache manager core data entity description
+                //    rather than hardcoding it with a string literal
+                NSEntityDescription *entityDescription = [SBBForwardCursorPagedResourceList entityForContext:self.cacheManager.cacheIOContext];
+                NSString *entityIDKeyPath = entityDescription.userInfo[@"entityIDKeyPath"];
+                
+                // -- set it in the JSON to the activityGuid we're fetching
+                [objectWithActivityGuid setValue:activityGuid forKeyPath:entityIDKeyPath];
+                objectJSON = [objectWithActivityGuid copy];
+            }
+            
+            // -- now process into the cache (if caching), and in any case, get the PONSO object
+            //    so we can check if we're done yet
+            SBBForwardCursorPagedResourceList *fcprl = (SBBForwardCursorPagedResourceList *)[self.objectManager objectFromBridgeJSON:objectJSON];
+            
+            // -- now see if we're done, and act accordingly
+            if (fcprl.hasNextValue) {
+                // not done, keep paging in more activities
+                NSDate *newOffset = fcprl.offsetBy;
+                if (accumulatedItems) {
+                    // if we're not caching or are ignoring cache, accumulate the raw list of items from Bridge
+                    // as we go
+                    [accumulatedItems addObjectsFromArray:fcprl.items];
+                }
+                [self fetchHistoricalActivitiesForGuid:activityGuid withParameters:parameters offsetBy:newOffset accumulatedItems:accumulatedItems completion:completion];
+            } else {
+                // done, call completion
+                if (completion) {
+                    if (accumulatedItems) {
+                        completion([accumulatedItems copy], error);
+                    } else {
+                        completion(fcprl.items, error);
+                    }
+                }
+            }
+        }
+    }];
+}
+
+- (NSArray *)filterAndMapTasks:(NSArray *)tasks scheduledFrom:(NSDate *)scheduledFrom to:(NSDate *)scheduledTo
+{
+    if (!tasks) {
+        return nil;
+    }
+    
+    NSMutableArray *requestedTasks = [[self filterTasks:tasks scheduledFrom:scheduledFrom to:scheduledTo] mutableCopy];
+    [self mapSubObjectsInTaskList:requestedTasks];
+    return [requestedTasks copy];
+}
+
+- (SBBForwardCursorPagedResourceList *)cachedListForActivityGuid:(NSString *)activityGuid
+{
+    SBBForwardCursorPagedResourceList *fcprl = (SBBForwardCursorPagedResourceList *)[self.cacheManager cachedObjectOfType:[SBBForwardCursorPagedResourceList entityName] withId:activityGuid createIfMissing:NO];
+
+    return fcprl;
+}
+
 - (NSURLSessionTask *)getScheduledActivitiesForGuid:(NSString *)activityGuid scheduledFrom:(NSDate *)scheduledFrom to:(NSDate *)scheduledTo cachingPolicy:(SBBCachingPolicy)policy withCompletion:(SBBActivityManagerGetCompletionBlock)completion
 {
+    // if we're going straight to cache, just get it and get out
+    if (gSBBUseCache && policy == SBBCachingPolicyCachedOnly) {
+        if (completion) {
+            SBBForwardCursorPagedResourceList *list = [self cachedListForActivityGuid:activityGuid];
+            NSArray *requestedTasks = [self filterAndMapTasks:list.items scheduledFrom:scheduledFrom to:scheduledTo];
+            completion(requestedTasks, nil);
+        }
+        
+        return nil;
+    }
     
+    NSDictionary *parameters = @{@"scheduledOnStart": [scheduledFrom ISO8601StringUTC],
+                                 @"scheduledOnEnd": [scheduledTo ISO8601StringUTC],
+                                 @"pageSize": @(kFetchPageSize)};
+    NSMutableArray *accumulatedItems = nil;
+    if (!gSBBUseCache || policy == SBBCachingPolicyNoCaching) {
+        accumulatedItems = [NSMutableArray array];
+    }
+    return [self fetchHistoricalActivitiesForGuid:activityGuid withParameters:parameters offsetBy:nil accumulatedItems:accumulatedItems completion:^(NSArray * _Nullable activitiesList, NSError * _Nullable error) {
+        if (completion) {
+            NSArray *requestedTasks = [self filterAndMapTasks:activitiesList scheduledFrom:scheduledFrom to:scheduledTo];
+            completion(requestedTasks, error);
+        }
+    }];
 }
 
 - (NSURLSessionTask *)getScheduledActivitiesForGuid:(NSString *)activityGuid scheduledFrom:(NSDate *)scheduledFrom to:(NSDate *)scheduledTo withCompletion:(SBBActivityManagerGetCompletionBlock)completion
 {
-    return [self getScheduledActivitiesForGuid:activityGuid scheduledFrom:scheduledFrom to:scheduledTo cachingPolicy:SBBCachingPolicyFallBackToCached withCompletion:completion];
+    SBBCachingPolicy policy = gSBBUseCache ? SBBCachingPolicyFallBackToCached : SBBCachingPolicyNoCaching;
+
+    return [self getScheduledActivitiesForGuid:activityGuid scheduledFrom:scheduledFrom to:scheduledTo cachingPolicy:policy withCompletion:completion];
 }
 
 // Note: this method blocks until it gets its turn in the cache IO context queue

--- a/BridgeSDK/BridgeAPI/SBBActivityManagerInternal.h
+++ b/BridgeSDK/BridgeAPI/SBBActivityManagerInternal.h
@@ -33,6 +33,7 @@
 
 /* CONSTANTS */
 extern NSString * const kSBBActivityAPI;
+extern NSString * const kSBBHistoricalActivityAPIFormat;
 
 @protocol SBBActivityManagerInternalProtocol <SBBActivityManagerProtocol>
 

--- a/BridgeSDK/BridgeAPI/SBBJSONValue.h
+++ b/BridgeSDK/BridgeAPI/SBBJSONValue.h
@@ -44,7 +44,7 @@
 
 @protocol SBBJSONValue <NSObject>
 
-- (BOOL)isValidJSON;
+- (BOOL)validateJSONWithError:(NSError **)error;
 
 @end
 

--- a/BridgeSDK/BridgeAPI/SBBJSONValue.h
+++ b/BridgeSDK/BridgeAPI/SBBJSONValue.h
@@ -1,0 +1,69 @@
+//
+//  SBBJSONValue.h
+//  BridgeSDK
+//
+//
+// Copyright (c) 2017, Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import <Foundation/Foundation.h>
+
+/**
+ This protocol and set of categories lets us specify "any JSON-serializable object" as id<SBBJSONValue>.
+ 
+ Note that we still need to call isValidJSON on the object to validate that it is in fact JSON all the
+ way down, since Objective-C doesn't have any way to apply categories only to instances of containers declared
+ with specific type specifiers.
+ 
+ */
+
+@protocol SBBJSONValue <NSObject>
+
+- (BOOL)isValidJSON;
+
+@end
+
+@interface NSDictionary (SBBJSONValue)<SBBJSONValue>
+
+@end
+
+@interface NSArray (SBBJSONValue)<SBBJSONValue>
+
+@end
+
+@interface NSString (SBBJSONValue)<SBBJSONValue>
+
+@end
+
+@interface NSNumber (SBBJSONValue)<SBBJSONValue>
+
+@end
+
+@interface NSNull (SBBJSONValue)<SBBJSONValue>
+
+@end

--- a/BridgeSDK/BridgeAPI/SBBJSONValue.m
+++ b/BridgeSDK/BridgeAPI/SBBJSONValue.m
@@ -1,0 +1,97 @@
+//
+//  SBBJSONValue.h
+//  BridgeSDK
+//
+//
+// Copyright (c) 2017, Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import"SBBJSONValue.h"
+
+@implementation NSDictionary (SBBJSONValue)
+
+- (BOOL)isValidJSON {
+    // all keys must be strings
+    for (NSObject *key in self.allKeys) {
+        if (![key isKindOfClass:[NSString class]]) {
+            return NO;
+        }
+    }
+    
+    // all values must conform to SBBJSONValue and be valid JSON themselves
+    for (id<SBBJSONValue> value in self.allValues) {
+        if (![value conformsToProtocol:@protocol(SBBJSONValue)] ||
+            ![value isValidJSON]) {
+            return NO;
+        }
+    }
+    
+    return YES;
+}
+
+@end
+
+@implementation NSArray (SBBJSONValue)
+
+- (BOOL)isValidJSON {
+    // all values must conform to SBBJSONValue and be valid JSON themselves
+    for (id<SBBJSONValue> value in self) {
+        if (![value conformsToProtocol:@protocol(SBBJSONValue)] ||
+            ![value isValidJSON]) {
+            return NO;
+        }
+    }
+    
+    return YES;
+}
+
+@end
+
+@implementation NSString (SBBJSONValue)
+
+- (BOOL)isValidJSON {
+    return YES;
+}
+
+@end
+
+@implementation NSNumber (SBBJSONValue)
+
+- (BOOL)isValidJSON {
+    return YES;
+}
+
+@end
+
+@implementation NSNull (SBBJSONValue)
+
+- (BOOL)isValidJSON {
+    return YES;
+}
+
+@end

--- a/BridgeSDK/BridgeSDK.h
+++ b/BridgeSDK/BridgeSDK.h
@@ -51,6 +51,7 @@ extern const unsigned char BridgeSDKVersionString[];
 #import <BridgeSDK/SBBBridgeErrorUIDelegate.h>
 #import <BridgeSDK/SBBBridgeInfoProtocol.h>
 #import <BridgeSDK/SBBBridgeInfo.h>
+#import <BridgeSDK/SBBJSONValue.h>
 #import <BridgeSDK/SBBComponent.h>
 #import <BridgeSDK/SBBComponentManager.h>
 #import <BridgeSDK/SBBConsentManager.h>

--- a/BridgeSDK/Internal/SBBEncryptor.m
+++ b/BridgeSDK/Internal/SBBEncryptor.m
@@ -34,7 +34,7 @@
 #import "SBBEncryptor.h"
 #import "BridgeSDK+Internal.h"
 @import UIKit;
-#import <OpenSSL/openssl.h>
+#import <openssl/openssl.h>
 
 static NSString *kEncryptedDataFilename = @"encrypted.zip";
 static NSString *kEncryptedFileBaseFolder = @"encryptor";

--- a/BridgeSDK/Networking/SBBErrors.h
+++ b/BridgeSDK/Networking/SBBErrors.h
@@ -52,7 +52,8 @@ typedef NS_ENUM(NSInteger, SBBErrorCode)
     SBBErrorCodeTempFileError = -1102,
     SBBErrorCodeTempFileReadError = -1103,
     
-    SBBErrorCodeNotAValidSurveyRef = -1200
+    SBBErrorCodeNotAValidSurveyRef = -1200,
+    SBBErrorCodeNotAValidJSONObject = -1201
 };
 
 

--- a/BridgeSDK/mogenerator_ponso_templates/code/ModelObject.m
+++ b/BridgeSDK/mogenerator_ponso_templates/code/ModelObject.m
@@ -147,6 +147,24 @@
     self.sourceDictionaryRepresentation = dictionary;
 }
 
+- (void)reconcileWithDictionaryRepresentation:(NSDictionary *)dictionary objectManager:(id<SBBObjectManagerInternalProtocol>)objectManager
+{
+    // This method is only called during caching operations.
+    
+    // This default implementation just calls updateWithDictionaryRepresentation:objectManager: for
+    // entities that aren't marked as having client-writable fields, either directly, or by implication
+    // by virtue of being marked as extendable; otherwise it does nothing. Thus, for non-client-modifiable
+    // objects the server version is always canonical, and for client-modifiable objects the locally
+    // cached version takes precedence.
+    
+    // Subclasses can override this method to provide different behavior.
+    NSManagedObjectContext *cacheContext = objectManager.cacheManager.cacheIOContext;
+    NSEntityDescription *entity = [self entityForContext:cacheContext];
+    if (!(entity.userInfo[@"hasClientWritableFields"] || entity.userInfo[@"isExtendable"])) {
+        [self updateWithDictionaryRepresentation:dictionary objectManager:objectManager];
+    }
+}
+
 - (NSDictionary *)dictionaryRepresentation
 {
     return [self dictionaryRepresentationFromObjectManager:self.creatingObjectManager ?: SBBComponent(SBBObjectManager)];

--- a/BridgeSDK/mogenerator_ponso_templates/code/ModelObject.m
+++ b/BridgeSDK/mogenerator_ponso_templates/code/ModelObject.m
@@ -255,6 +255,13 @@
     // generated subclasses will override this
 }
 
+- (void)releaseManagedObject:(NSManagedObject *)managedObject inContext:(NSManagedObjectContext *)cacheContext
+{
+    // subclasses that are directly cacheable, and can be a member of more than one to-many relationship,
+    // should override this to only delete when no longer a member of any of them
+    [cacheContext deleteObject:managedObject];
+}
+
 - (void)dealloc
 {
     self.sourceDictionaryRepresentation = nil;

--- a/BridgeSDK/mogenerator_ponso_templates/code/ModelObjectInternal.h
+++ b/BridgeSDK/mogenerator_ponso_templates/code/ModelObjectInternal.h
@@ -15,7 +15,13 @@
 
 - (id)initWithDictionaryRepresentation:(NSDictionary *)dictionary objectManager:(id<SBBObjectManagerProtocol>)objectManager;
 - (void)updateWithDictionaryRepresentation:(NSDictionary *)dictionary objectManager:(id<SBBObjectManagerProtocol>)objectManager;
+
+// This method is only called by the cache manager, and is always followed by updating the object to CoreData cache,
+// so no need to do so from within the method. Override it to customize how the Bridge server version of an object
+// gets reconciled with the locally-cached version. The default behavior is server-wins for non-client-writable objects,
+// and cache-wins for objects with any client-writable fields.
 - (void)reconcileWithDictionaryRepresentation:(NSDictionary *)dictionary objectManager:(id<SBBObjectManagerInternalProtocol>)objectManager;
+
 - (NSDictionary *)dictionaryRepresentationFromObjectManager:(id<SBBObjectManagerProtocol>)objectManager;
 
 - (BOOL)isDirectlyCacheableWithContext:(NSManagedObjectContext *)context;

--- a/BridgeSDK/mogenerator_ponso_templates/code/ModelObjectInternal.h
+++ b/BridgeSDK/mogenerator_ponso_templates/code/ModelObjectInternal.h
@@ -32,6 +32,7 @@
 // These methods MUST be called on cacheContext's queue.
 - (NSManagedObject *)createInContext:(NSManagedObjectContext *)cacheContext withObjectManager:(id<SBBObjectManagerProtocol>)objectManager cacheManager:(id<SBBCacheManagerProtocol>)cacheManager;
 - (void)updateManagedObject:(NSManagedObject *)managedObject withObjectManager:(id<SBBObjectManagerProtocol>)objectManager cacheManager:(id<SBBCacheManagerProtocol>)cacheManager;
+- (void)releaseManagedObject:(NSManagedObject *)managedObject inContext:(NSManagedObjectContext *)cacheContext;
 
 - (NSEntityDescription *)entityForContext:(NSManagedObjectContext *)context;
 

--- a/BridgeSDK/mogenerator_ponso_templates/code/ModelObjectInternal.h
+++ b/BridgeSDK/mogenerator_ponso_templates/code/ModelObjectInternal.h
@@ -15,6 +15,7 @@
 
 - (id)initWithDictionaryRepresentation:(NSDictionary *)dictionary objectManager:(id<SBBObjectManagerProtocol>)objectManager;
 - (void)updateWithDictionaryRepresentation:(NSDictionary *)dictionary objectManager:(id<SBBObjectManagerProtocol>)objectManager;
+- (void)reconcileWithDictionaryRepresentation:(NSDictionary *)dictionary objectManager:(id<SBBObjectManagerInternalProtocol>)objectManager;
 - (NSDictionary *)dictionaryRepresentationFromObjectManager:(id<SBBObjectManagerProtocol>)objectManager;
 
 - (BOOL)isDirectlyCacheableWithContext:(NSManagedObjectContext *)context;

--- a/BridgeSDK/mogenerator_ponso_templates/templates/machine.m.motemplate
+++ b/BridgeSDK/mogenerator_ponso_templates/templates/machine.m.motemplate
@@ -617,11 +617,11 @@ static id dynamicGetterIMP(id self, SEL _cmd)
         }
 	}
 
-    // now delete any objects that aren't still in the relationship
+    // now release any objects that aren't still in the relationship (they will be deleted when they no longer belong to any to-many relationships)
     for (NSManagedObject *relMo in <$Relationship.name$>Copy) {
         <$if Relationship.inverseRelationship.isToMany$>if (![[relMo valueForKey:@"<$Relationship.inverseRelationship.name$>"] count]) {
         <$else$>if (![relMo valueForKey:@"<$Relationship.inverseRelationship.name$>"]) {
-        <$endif$>   [cacheContext deleteObject:relMo];
+        <$endif$>   [self releaseManagedObject:relMo inContext:cacheContext];
         }
     }
 

--- a/BridgeSDKTests/SBBActivityManagerUnitTests.m
+++ b/BridgeSDKTests/SBBActivityManagerUnitTests.m
@@ -102,4 +102,106 @@
     }];
 }
 
+- (void)testGetScheduledActivitiesForGuid {
+    NSString *activityGuid = @"task-1-guid";
+    NSString *fromDateString = @"2017-03-30T00:00:00.000Z";
+    NSString *toDateString = @"2017-04-01T00:00:00.000Z";
+    NSString *task1ScheduledString = @"2017-03-31T04:55:07.867Z";
+    NSString *task2ScheduledString = @"2017-03-30T04:55:07.867Z";
+    NSString *scheduledActivityGuid1 = [NSString stringWithFormat:@"%@:%@", activityGuid, task1ScheduledString];
+    NSString *scheduledActivityGuid2 = [NSString stringWithFormat:@"%@:%@", activityGuid, task2ScheduledString];
+    NSDate *fromDate = [NSDate dateWithISO8601String:fromDateString];
+    NSDate *toDate = [NSDate dateWithISO8601String:toDateString];
+    NSDate *task1Scheduled = [NSDate dateWithISO8601String:task1ScheduledString];
+    NSDate *task2Scheduled = [NSDate dateWithISO8601String:task2ScheduledString];
+    NSDictionary *task1 =
+    @{
+      @"type": @"ScheduledActivity",
+      @"guid": scheduledActivityGuid1,
+      @"activity": @{
+              @"activityType": @"survey",
+              @"label": @"This is a survey",
+              @"labelDetail": @"It will be long and boring and tedious to fill out",
+              @"survey": @{
+                      @"identifier": @"this-is-a-survey",
+                      @"guid": @"guid-goes-here",
+                      @"createdOn": @"2014-12-12T18:26:01.855Z",
+                      @"href": @"url-to-retrieve-survey/guid-goes-here/2014-12-12T18:26:01.855Z",
+                      @"type": @"SurveyReference"
+                      },
+              @"type": @"Activity"
+              },
+      @"scheduledOn": task1ScheduledString,
+      @"expiresOn": @"2017-04-01T04:55:07.867Z",
+      @"status": @"available"
+      };
+    NSDictionary *task2 =
+    @{
+      @"type": @"ScheduledActivity",
+      @"guid": scheduledActivityGuid2,
+      @"activity": @{
+              @"activityType": @"survey",
+              @"label": @"This is a survey",
+              @"labelDetail": @"It will be long and boring and tedious to fill out",
+              @"survey": @{
+                      @"identifier": @"this-is-a-survey",
+                      @"guid": @"guid-goes-here",
+                      @"createdOn": @"2014-12-12T18:26:01.855Z",
+                      @"href": @"url-to-retrieve-survey/guid-goes-here/2014-12-12T18:26:01.855Z",
+                      @"type": @"SurveyReference"
+                      },
+              @"type": @"Activity"
+              },
+      @"scheduledOn": task2ScheduledString,
+      @"expiresOn": @"2017-03-31T04:55:07.867Z",
+      @"status": @"available"
+      };
+    NSDictionary *response1 = @{
+                               @"type": @"ForwardCursorPagedResourceList",
+                               @"items": @[task1],
+                               @"offsetBy": @"2017-03-31T00:00:00.000",
+                               @"hasNext": @(YES),
+                               @"scheduledOnStart": fromDateString,
+                               @"scheduledOnEnd": toDateString,
+                               @"pageSize": @(1)
+                               };
+    NSDictionary *response2 = @{
+                                @"type": @"ForwardCursorPagedResourceList",
+                                @"items": @[task2],
+                                @"hasNext": @(NO),
+                                @"scheduledOnStart": fromDateString,
+                                @"scheduledOnEnd": toDateString,
+                                @"pageSize": @(1)
+                                };
+    NSString *endpoint = [NSString stringWithFormat:kSBBHistoricalActivityAPIFormat, @"task-1-guid"];
+    [self.mockURLSession setJson:response1 andResponseCode:200 forEndpoint:endpoint andMethod:@"GET"];
+    [self.mockURLSession setJson:response2 andResponseCode:200 forEndpoint:endpoint andMethod:@"GET"];
+    
+    id<SBBActivityManagerProtocol> tMan = SBBComponent(SBBActivityManager);
+    
+    XCTestExpectation *expectGotActivities = [self expectationWithDescription:@"Got historical activities"];
+    
+    [tMan getScheduledActivitiesForGuid:activityGuid scheduledFrom:fromDate to:toDate withCompletion:^(NSArray *tasks, NSError *error) {
+        XCTAssert([tasks isKindOfClass:[NSArray class]], @"Converted incoming object to NSArray");
+        XCTAssert(tasks.count == 2, @"Expected to retrieve 2 historical activities, got %@", @(tasks.count));
+        if (tasks.count) {
+            SBBScheduledActivity *task0 = tasks[0];
+            XCTAssert([task0 isKindOfClass:[SBBScheduledActivity class]], @"Converted items to NSArray of SBBScheduledActivity objects");
+            SBBActivity *activity0 = task0.activity;
+            XCTAssert([activity0 isKindOfClass:[SBBActivity class]], @"Converted 'activity' json to an SBBActivity object");
+            SBBScheduledActivity *task1 = tasks[1];
+            SBBActivity *activity1 = task1.activity;
+            XCTAssert([activity1 isKindOfClass:[SBBActivity class]], @"Activity of second task is also an SBBActivity object");
+            XCTAssertGreaterThan(task0.scheduledOn, task1.scheduledOn, @"Expected later task first in the array but the order instead is %@ :: %@", task0.scheduledOn, task1.scheduledOn);
+        }
+        [expectGotActivities fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:5.0 handler:^(NSError *error) {
+        if (error) {
+            NSLog(@"Timeout getting historical activities: %@", error);
+        }
+    }];
+}
+
 @end

--- a/BridgeSDKTests/SBBActivityManagerUnitTests.m
+++ b/BridgeSDKTests/SBBActivityManagerUnitTests.m
@@ -9,6 +9,7 @@
 #import "SBBBridgeAPIUnitTestCase.h"
 #import "SBBActivityManagerInternal.h"
 #import "SBBBridgeObjects.h"
+#import "ModelObjectInternal.h"
 
 @interface SBBActivityManagerUnitTests : SBBBridgeAPIUnitTestCase
 
@@ -73,7 +74,7 @@
                                   @"total": @(tasks.count)
                                   };
     [self.mockURLSession setJson:response andResponseCode:200 forEndpoint:kSBBActivityAPI andMethod:@"GET"];
-    id<SBBActivityManagerProtocol> tMan = SBBComponent(SBBActivityManager);
+    SBBActivityManager *tMan = [SBBActivityManager managerWithAuthManager:SBBComponent(SBBAuthManager) networkManager:SBBComponent(SBBBridgeNetworkManager) objectManager:self.objectManager];
     
     XCTestExpectation *expectGotActivities = [self expectationWithDescription:@"Got scheduled activities"];
 
@@ -104,10 +105,10 @@
 
 - (void)testGetScheduledActivitiesForGuid {
     NSString *activityGuid = @"task-1-guid";
-    NSString *fromDateString = @"2017-03-30T00:00:00.000Z";
-    NSString *toDateString = @"2017-04-01T00:00:00.000Z";
-    NSString *task1ScheduledString = @"2017-03-31T04:55:07.867Z";
-    NSString *task2ScheduledString = @"2017-03-30T04:55:07.867Z";
+    NSString *fromDateString = @"2017-03-30T00:00:00.000";
+    NSString *toDateString = @"2017-04-01T00:00:00.000";
+    NSString *task1ScheduledString = @"2017-03-31T04:55:07.867";
+    NSString *task2ScheduledString = @"2017-03-30T04:55:07.867";
     NSString *scheduledActivityGuid1 = [NSString stringWithFormat:@"%@:%@", activityGuid, task1ScheduledString];
     NSString *scheduledActivityGuid2 = [NSString stringWithFormat:@"%@:%@", activityGuid, task2ScheduledString];
     NSDate *fromDate = [NSDate dateWithISO8601String:fromDateString];
@@ -130,7 +131,7 @@
               @"type": @"Activity"
               },
       @"scheduledOn": task1ScheduledString,
-      @"expiresOn": @"2017-04-01T04:55:07.867Z",
+      @"expiresOn": @"2017-04-01T04:55:07.867",
       @"status": @"available"
       };
     NSDictionary *task2 =
@@ -151,7 +152,7 @@
               @"type": @"Activity"
               },
       @"scheduledOn": task2ScheduledString,
-      @"expiresOn": @"2017-03-31T04:55:07.867Z",
+      @"expiresOn": @"2017-03-31T04:55:07.867",
       @"status": @"available"
       };
     NSDictionary *response1 = @{
@@ -175,14 +176,14 @@
     [self.mockURLSession setJson:response1 andResponseCode:200 forEndpoint:endpoint andMethod:@"GET"];
     [self.mockURLSession setJson:response2 andResponseCode:200 forEndpoint:endpoint andMethod:@"GET"];
     
-    id<SBBActivityManagerProtocol> tMan = SBBComponent(SBBActivityManager);
+    SBBActivityManager *tMan = [SBBActivityManager managerWithAuthManager:SBBComponent(SBBAuthManager) networkManager:SBBComponent(SBBBridgeNetworkManager) objectManager:self.objectManager];
     
     XCTestExpectation *expectGotActivities = [self expectationWithDescription:@"Got historical activities"];
     
     [tMan getScheduledActivitiesForGuid:activityGuid scheduledFrom:fromDate to:toDate withCompletion:^(NSArray *tasks, NSError *error) {
         XCTAssert([tasks isKindOfClass:[NSArray class]], @"Converted incoming object to NSArray");
         XCTAssert(tasks.count == 2, @"Expected to retrieve 2 historical activities, got %@", @(tasks.count));
-        if (tasks.count) {
+        if (tasks.count == 2) {
             SBBScheduledActivity *task0 = tasks[0];
             XCTAssert([task0 isKindOfClass:[SBBScheduledActivity class]], @"Converted items to NSArray of SBBScheduledActivity objects");
             SBBActivity *activity0 = task0.activity;
@@ -190,7 +191,7 @@
             SBBScheduledActivity *task1 = tasks[1];
             SBBActivity *activity1 = task1.activity;
             XCTAssert([activity1 isKindOfClass:[SBBActivity class]], @"Activity of second task is also an SBBActivity object");
-            XCTAssertGreaterThan(task0.scheduledOn, task1.scheduledOn, @"Expected later task first in the array but the order instead is %@ :: %@", task0.scheduledOn, task1.scheduledOn);
+            XCTAssert([task0.scheduledOn compare:task1.scheduledOn] == NSOrderedDescending, @"Expected later task first in the array but the order instead is %@ :: %@", task0.scheduledOn, task1.scheduledOn);
         }
         [expectGotActivities fulfill];
     }];
@@ -198,6 +199,111 @@
     [self waitForExpectationsWithTimeout:5.0 handler:^(NSError *error) {
         if (error) {
             NSLog(@"Timeout getting historical activities: %@", error);
+        }
+    }];
+}
+
+- (void)testSetClientData {
+    NSDictionary *task =
+    @{
+      @"type": @"ScheduledActivity",
+      @"guid": @"testSetClientData-task-guid",
+      @"activity": @{
+              @"activityType": @"survey",
+              @"label": @"This is a survey",
+              @"labelDetail": @"It will be long and boring and tedious to fill out",
+              @"survey": @{
+                      @"identifier": @"this-is-a-survey",
+                      @"guid": @"guid-goes-here",
+                      @"createdOn": @"2014-12-12T18:26:01.855Z",
+                      @"href": @"url-to-retrieve-survey/guid-goes-here/2014-12-12T18:26:01.855Z",
+                      @"type": @"SurveyReference"
+                      },
+              @"type": @"Activity"
+              },
+      @"scheduledOn": @"2017-03-31T04:55:07.867Z",
+      @"expiresOn": @"2017-04-01T04:55:07.867Z",
+      @"status": @"available"
+      };
+    
+    SBBActivityManager *tMan = [SBBActivityManager managerWithAuthManager:SBBComponent(SBBAuthManager) networkManager:SBBComponent(SBBBridgeNetworkManager) objectManager:self.objectManager];
+    
+    // get a scheduledActivity with no clientData into the cache
+    SBBScheduledActivity *scheduledActivity = [self.objectManager objectFromBridgeJSON:task];
+    
+    // attempt to set it to non-JSON, ensure completion handler called with error set appropriately
+    NSDictionary *pseudoJSON =
+    @{
+      @"thing": @{
+              @"thing1": @"today's-date-as-a-string",
+              @"thing2": [NSDate date]
+              }
+      };
+    
+    XCTestExpectation *expectError = [self expectationWithDescription:@"Attempting to set non-valid JSON"];
+
+    [tMan setClientData:pseudoJSON forScheduledActivity:scheduledActivity withCompletion:^(id  _Nullable responseObject, NSError * _Nullable error) {
+        XCTAssertNotNil(error, @"Error should not be nil but is nil; response: %@", responseObject);
+        XCTAssertNil(scheduledActivity.clientData, @"clientData should be nil but is: %@", scheduledActivity.clientData);
+        [expectError fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:5.0 handler:^(NSError *error) {
+        if (error) {
+            NSLog(@"Timeout attempting to set non-valid JSON: %@", error);
+        }
+    }];
+    
+    // set it to JSON, verify that it's set correclty both in PONSO object and Core Data cache
+    NSDictionary *realJSON =
+    @{
+      @"thing": @{
+              @"thing1": @"today's-date-as-a-string",
+              @"thing2": [[NSDate date] ISO8601StringUTC]
+              },
+      @"anotherThing": @[
+              @"anotherThing1",
+              @(12345),
+              @(NO),
+              @(3.14159),
+              @{
+                  @"andAnotherThing": @"never mind"
+                  }
+              ]
+      };
+    
+    XCTestExpectation *expectSet = [self expectationWithDescription:@"Setting valid JSON"];
+    
+    [tMan setClientData:realJSON forScheduledActivity:scheduledActivity withCompletion:^(id  _Nullable responseObject, NSError * _Nullable error) {
+        XCTAssertEqualObjects(realJSON, scheduledActivity.clientData, @"Expected PONSO to have same JSON as was set");
+        NSManagedObjectContext *context = self.cacheManager.cacheIOContext;
+        NSManagedObject *cachedActivity = [self.cacheManager cachedObjectForBridgeObject:scheduledActivity inContext:context];
+        id cachedJSON = [cachedActivity valueForKey:NSStringFromSelector(@selector(clientData))];
+        XCTAssertEqualObjects(realJSON, cachedJSON, "Expected managed object to have same JSON as was set");
+        [expectSet fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:5.0 handler:^(NSError *error) {
+        if (error) {
+            NSLog(@"Timeout attempting to set valid JSON: %@", error);
+        }
+    }];
+
+    // set it to [NSNull null], verify that it's nil in both places
+    XCTestExpectation *expectNulled = [self expectationWithDescription:@"Setting to null"];
+    
+    [tMan setClientData:[NSNull null] forScheduledActivity:scheduledActivity withCompletion:^(id  _Nullable responseObject, NSError * _Nullable error) {
+        XCTAssertNil(scheduledActivity.clientData, @"Expected PONSO to have nil but have:\n%@", scheduledActivity.clientData);
+        NSManagedObjectContext *context = self.cacheManager.cacheIOContext;
+        NSManagedObject *cachedActivity = [self.cacheManager cachedObjectForBridgeObject:scheduledActivity inContext:context];
+        id cachedJSON = [cachedActivity valueForKey:NSStringFromSelector(@selector(clientData))];
+        XCTAssertNil(cachedJSON, "Expected managed object to have nil but have:\n%@", cachedJSON);
+        [expectNulled fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:5.0 handler:^(NSError *error) {
+        if (error) {
+            NSLog(@"Timeout attempting to null clientData: %@", error);
         }
     }];
 }

--- a/BridgeSDKTests/SBBActivityManagerUnitTests.m
+++ b/BridgeSDKTests/SBBActivityManagerUnitTests.m
@@ -112,8 +112,6 @@
     NSString *scheduledActivityGuid2 = [NSString stringWithFormat:@"%@:%@", activityGuid, task2ScheduledString];
     NSDate *fromDate = [NSDate dateWithISO8601String:fromDateString];
     NSDate *toDate = [NSDate dateWithISO8601String:toDateString];
-    NSDate *task1Scheduled = [NSDate dateWithISO8601String:task1ScheduledString];
-    NSDate *task2Scheduled = [NSDate dateWithISO8601String:task2ScheduledString];
     NSDictionary *task1 =
     @{
       @"type": @"ScheduledActivity",

--- a/BridgeSDKTests/_SBBTestBridgeObject.m
+++ b/BridgeSDKTests/_SBBTestBridgeObject.m
@@ -496,10 +496,10 @@
         }
 	}
 
-    // now delete any objects that aren't still in the relationship
+    // now release any objects that aren't still in the relationship (they will be deleted when they no longer belong to any to-many relationships)
     for (NSManagedObject *relMo in bridgeObjectArrayFieldCopy) {
         if (![relMo valueForKey:@"parentTestBridgeObject"]) {
-           [cacheContext deleteObject:relMo];
+           [self releaseManagedObject:relMo inContext:cacheContext];
         }
     }
 
@@ -530,10 +530,10 @@
         }
 	}
 
-    // now delete any objects that aren't still in the relationship
+    // now release any objects that aren't still in the relationship (they will be deleted when they no longer belong to any to-many relationships)
     for (NSManagedObject *relMo in bridgeObjectSetFieldCopy) {
         if (![relMo valueForKey:@"testBridgeObjectSet"]) {
-           [cacheContext deleteObject:relMo];
+           [self releaseManagedObject:relMo inContext:cacheContext];
         }
     }
 


### PR DESCRIPTION
Support for the clientData field in ScheduledActivity, and for the new Bridge API for fetching historical ScheduledActivity objects. Caveat that integration tests are currently failing due to a bug in the server implementation, which Alx will fix.

Also fixed a bunch of openssl "non-portable path" warnings.