### PR TITLE
Conditional test builds

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,17 +35,30 @@ platform :ios do
     )
   end
 
-  desc "Runs all the tests"
+  desc "Run tests"
   lane :test do |options|
-    if options[:scheme]
+    scheme = options[:scheme]
+    build_for_testing = options[:build_for_testing]
+    only_testing = '"BridgeSDKTests","BridgeSDKIntegrationTests"'
+
+    if options[:only_testing]
+       only_testing = options[:only_testing]
+    end
+
+    if build_for_testing
        scan(
-         scheme: options[:scheme],
+         scheme: "#{scheme}",
+         build_for_testing: true
+       )
+    else
+       sh("echo #{only_testing}")
+       scan(
+         scheme: "#{scheme}",
+         only_testing: "#{only_testing}",
          xcargs: [
            'SAGE_ADMIN_EMAIL=$SAGE_ADMIN_EMAIL',
            'SAGE_ADMIN_PASSWORD=$SAGE_ADMIN_PASSWORD']
         )
-    else
-      scan
     end
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -51,7 +51,6 @@ platform :ios do
          build_for_testing: true
        )
     else
-       sh("echo #{only_testing}")
        scan(
          scheme: "#{scheme}",
          only_testing: "#{only_testing}",

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -38,7 +38,7 @@ Build the documentation
 ```
 fastlane ios test
 ```
-Runs all the tests
+Run tests
 
 ----
 

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -2,13 +2,13 @@
 set -ex
 # show available schemes
 # xcodebuild -list -project ./BridgeSDK.xcodeproj
+cp BridgeAdminCredentials.plist ../BridgeAdminCredentials.plist
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
     bundle exec fastlane doc scheme:"BridgeSDK"
     bundle exec fastlane test scheme:"BridgeSDK" only_testing:"BridgeSDKTests"
 fi
 if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
     bundle exec fastlane doc scheme:"BridgeSDK"
-    cp BridgeAdminCredentials.plist ../BridgeAdminCredentials.plist
     bundle exec fastlane test scheme:"BridgeSDK"
 fi
 exit $?

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -4,6 +4,7 @@ set -ex
 # xcodebuild -list -project ./BridgeSDK.xcodeproj
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
     bundle exec fastlane doc scheme:"BridgeSDK"
+    bundle exec fastlane test scheme:"BridgeSDK" only_testing:"BridgeSDKTests"
 fi
 if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
     bundle exec fastlane doc scheme:"BridgeSDK"


### PR DESCRIPTION
* Allow building project without running tests.
* Allow running a specific test suites.  By default both unit and
  integration tests are executed when building "BridgeSDK" scheme

Usage

 Build without running tests:
 bundle exec fastlane test scheme:"BridgeSDK" build_for_testing:true

 Build and run only unit tests:
 bundle exec fastlane test scheme:"BridgeSDK" only_testing:"BridgeSDKTests"