### PR TITLE
Add new auth delegate method

### DIFF
--- a/BridgeSDK/BridgeAPI/SBBAuthManager.h
+++ b/BridgeSDK/BridgeAPI/SBBAuthManager.h
@@ -117,6 +117,14 @@
 @optional
 
 /*!
+ *  Implement this delegate method if you want the Auth Manager to notify you when it has updated the UserSessionInfo (and StudyParticipant) as a result of signing in, whether due to user action or to auto-refreshing the session token, or signing out. If you use any of the information contained in either of those objects, you should implement this method and update your app's state accordingly each time it's called, so you know you always have the most current versions of those objects and you always know your app's state reflects the current state of the participant's account on the server.
+ *
+ *  @param authManager The auth manager instance making the delegate request.
+ *  @param sessionInfo The new user session info, or nil if signed out. By default, the SBBUserSessionInfo object (which includes a pointer to the SBBStudyParticipant object), unless the UserSessionInfo type has been mapped in SBBObjectManager setupMappingForType:toClass:fieldToPropertyMappings:.
+ */
+- (void)authManager:(nullable id<SBBAuthManagerProtocol>)authManager didReceiveUserSessionInfo:(nullable id)sessionInfo;
+
+/*!
  *  For backward compatibility only. Implement emailForAuthManager: instead, which will always be called by the SDK in preference to this.
  *
  *  @param authManager The auth manager instance making the delegate request.

--- a/BridgeSDKTests/SBBAuthManagerIntegrationTests.m
+++ b/BridgeSDKTests/SBBAuthManagerIntegrationTests.m
@@ -165,6 +165,7 @@
             NSLog(@"Error signing out from account %@:\n%@\nResponse: %@", consentedEmail, error, responseObject);
         }
         XCTAssert(!aMan.isAuthenticated && [responseObject[@"message"] isEqualToString:@"Signed out."], @"Successfully signed out");
+        XCTAssertNil(delegate.sessionInfo, @"Expected the delegate to have been told to clear the sessionInfo, but it still has this:\n%@", delegate.sessionInfo);
         [expectSignedOut fulfill];
     }];
     

--- a/BridgeSDKTests/SBBTestAuthManagerDelegate.h
+++ b/BridgeSDKTests/SBBTestAuthManagerDelegate.h
@@ -3,7 +3,7 @@
 //  BridgeSDK
 //
 //  Created by Erin Mounts on 10/2/14.
-//  Copyright (c) 2014 Sage Bionetworks. All rights reserved.
+//  Copyright (c) 2014-2017 Sage Bionetworks. All rights reserved.
 //
 
 #import "SBBAuthManager.h"
@@ -13,5 +13,7 @@
 @property (nonatomic, strong) NSString *email;
 @property (nonatomic, strong) NSString *password;
 @property (nonatomic, strong) NSString *sessionToken;
+
+@property (nonatomic, strong) id sessionInfo;
 
 @end

--- a/BridgeSDKTests/SBBTestAuthManagerDelegate.m
+++ b/BridgeSDKTests/SBBTestAuthManagerDelegate.m
@@ -3,7 +3,7 @@
 //  BridgeSDK
 //
 //  Created by Erin Mounts on 10/2/14.
-//  Copyright (c) 2014 Sage Bionetworks. All rights reserved.
+//  Copyright (c) 2014-2017 Sage Bionetworks. All rights reserved.
 //
 
 #import "SBBTestAuthManagerDelegate.h"
@@ -20,6 +20,11 @@
     _sessionToken = sessionToken;
     _email = email;
     _password = password;
+}
+
+- (void)authManager:(id<SBBAuthManagerProtocol>)authManager didReceiveUserSessionInfo:(id)sessionInfo
+{
+    _sessionInfo = sessionInfo;
 }
 
 - (NSString *)emailForAuthManager:(id<SBBAuthManagerProtocol>)authManager


### PR DESCRIPTION
…to let the delegate know what the new UserSessionInfo/StudyParticipant is upon signin, or to forget it upon signout. Because it’s stored encrypted in CoreData with the password as the encryption key, we can’t update it and send it to the delegate until after we’ve stored the password where the BridgeSDK can get at it, and since the auth delegate does that in the existing signin callback, we can’t just send it all in one delegate method, so instead there’s just this new optional delegate method to get just the UserSessionInfo/StudyParticipant once all that has been sorted out.