### PR TITLE
Fix longstanding cache path switching bug

### DIFF
--- a/BridgeSDK/BridgeAPI/SBBAuthManager.m
+++ b/BridgeSDK/BridgeAPI/SBBAuthManager.m
@@ -523,8 +523,7 @@ void dispatchSyncToKeychainQueue(dispatch_block_t dispatchBlock)
             });
         }
         
-        [(id <SBBUserManagerInternalProtocol>)SBBComponent(SBBUserManager) clearUserInfoFromCache];
-        [(id <SBBParticipantManagerInternalProtocol>)SBBComponent(SBBParticipantManager) clearUserInfoFromCache];
+        [self.cacheManager resetCache];
 
         if ([_authDelegate respondsToSelector:@selector(authManager:didReceiveUserSessionInfo:)]) {
             [_authDelegate authManager:self didReceiveUserSessionInfo:nil];


### PR DESCRIPTION
…that we previously avoided by the simple expedient of not accessing the cache before the email was set. That’s no longer an option, but now that we can retrieve all old ScheduledActivity objects, there’s no need to keep separate cache stores for different email addresses; we can just delete the cache on signOut and re-create it when next accessed.