### PR TITLE
No components before setup

### DIFF
--- a/BridgeSDK/BridgeAPI/SBBComponentManager.h
+++ b/BridgeSDK/BridgeAPI/SBBComponentManager.h
@@ -83,12 +83,15 @@
 /*!
  *  Return the registered instance of the component for the given class.
  *
+ *  If the study has not yet been set up (the shared SBBBridgeInfo object's studyIdentifier is nil), this method
+ *  will return nil for all components to prevent premature registration of defaults.
+ *
  *  If no instance is registered, and componentClass implements the SBBComponent protocol, this method will
  *  call the class's defaultComponent: class method and register the returned value as the instance for the class.
  *
  *  @param componentClass The class for which to get (or instantiate and register) the registered component instance.
  *
- *  @return The registered instance for the given componentClass.
+ *  @return The registered instance for the given componentClass, or nil if the study has not yet been set up.
  */
 + (id)component:(Class)componentClass;
 

--- a/BridgeSDK/BridgeAPI/SBBComponentManager.m
+++ b/BridgeSDK/BridgeAPI/SBBComponentManager.m
@@ -32,6 +32,7 @@
 
 #import "SBBComponentManager.h"
 #import "SBBComponent.h"
+#import "SBBBridgeInfo.h"
 
 #pragma mark ComponentWrapper
 
@@ -136,6 +137,12 @@ void dispatchSyncToCMQueue(void(^dispatchBlock)()) {
 
 + (id)component:(Class)componentClass
 {
+    // Until the study has been set up, don't allow access to any BridgeSDK components
+    // or cause any defaults to be created and registered.
+    if (![SBBBridgeInfo shared].studyIdentifier) {
+        return nil;
+    }
+    
   __block ComponentWrapper *cWrapper = nil;
   __block id component = nil;
   __block Class localClass = componentClass;

--- a/BridgeSDKTests/SBBActivityManagerIntegrationTests.m
+++ b/BridgeSDKTests/SBBActivityManagerIntegrationTests.m
@@ -68,7 +68,7 @@
         }
     }];
     
-    [self waitForExpectationsWithTimeout:5.0 handler:^(NSError *error) {
+    [self waitForExpectationsWithTimeout:10.0 handler:^(NSError *error) {
         if (error) {
             NSLog(@"Time out error trying to create and sign in to all-roles test user account:\n%@", error);
         }


### PR DESCRIPTION
Don’t allow access to registered components and don’t create and register any default components before the study has been set up.