### PR TITLE
update RNCryptor for xcode 9, ios 11

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "Submodules/RNCryptor"]
 	path = Submodules/RNCryptor
-	url = https://github.com/RNCryptor/RNCryptor.git
+	url = https://github.com/Sage-Bionetworks/RNCryptor.git
 [submodule "Submodules/ZipZap"]
 	path = Submodules/ZipZap
 	url = https://github.com/pixelglow/ZipZap.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8.2
+osx_image: xcode9.0
 xcode_project: BridgeSDK.xcodeproj
 xcode_scheme: BridgeSDK
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9.0
+osx_image: xcode9
 xcode_project: BridgeSDK.xcodeproj
 xcode_scheme: BridgeSDK
 cache:


### PR DESCRIPTION
now points at a branch in a Sage fork of RNCryptor