### PR TITLE
If the archive was not finalized then do so before uploading.

### DIFF
--- a/BridgeSDK/BridgeAPI/SBBDataArchive.h
+++ b/BridgeSDK/BridgeAPI/SBBDataArchive.h
@@ -39,6 +39,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SBBDataArchive : NSObject
 
+@property (nonatomic, readonly, getter=isCompleted) BOOL completed;
+
 @property (nonatomic, readonly) NSURL *unencryptedURL;
 
 @property (nonatomic, readonly, nullable) NSDictionary <NSString *, NSPredicate *> *jsonValidationMapping;

--- a/BridgeSDK/BridgeAPI/SBBDataArchive.m
+++ b/BridgeSDK/BridgeAPI/SBBDataArchive.m
@@ -223,6 +223,11 @@ static NSString * kJsonInfoFilename                 = @"info.json";
 //Compiles the final info.json file and inserts it into the zip archive.
 - (BOOL)completeArchive:(NSError **)error
 {
+    // Exit early if this method has already been called.
+    if (self.isCompleted) {
+        return YES;
+    }
+    
     BOOL success = YES;
     NSError *internalError = nil;
     if (!self.isEmpty) {
@@ -256,12 +261,20 @@ static NSString * kJsonInfoFilename                 = @"info.json";
             }
         }
     }
+    _completed = success;
     
     return success;
 }
 
 - (void)encryptAndUploadArchive
 {
+    // Check that the archive has been closed.
+    if (!self.isCompleted) {
+        if (![self completeArchive:nil]) {
+            return;
+        }
+    }
+    
     SBBEncryptor *encryptor = [SBBEncryptor new];
     
     [encryptor encryptFileAtURL:_unencryptedURL withCompletion:^(NSURL *url, NSError *error) {


### PR DESCRIPTION
Discovered during testing that no where in any of the frameworks is `completeArchive` being called. Not sure when this happened, but figured that the safest way to ensure that the archive is finalized (and thus actually has zipped files) would be to check before upload and encryption.