### PR TITLE
Fix a bug in cache management during tests

### DIFF
--- a/BridgeSDK/Internal/SBBCacheManager.m
+++ b/BridgeSDK/Internal/SBBCacheManager.m
@@ -721,12 +721,14 @@ void removeCoreDataQueueForPersistentStoreName(NSString *name)
             _cacheIOContext= nil;
             _managedObjectModel = nil;
             
-            NSURL *storeDirURL = [self storeDirURL];
-            NSFileManager *fm = [NSFileManager defaultManager];
-            if ([fm fileExistsAtPath:storeDirURL.path]) {
-                if (![fm removeItemAtURL:storeDirURL error:&error]) {
-                    NSLog(@"Unable to delete SQLite db files directory at %@ : error %@, %@", storeDirURL, error, [error userInfo]);
-                    return;
+            if (![_persistentStoreType isEqualToString:NSInMemoryStoreType]) {
+                NSURL *storeDirURL = [self storeDirURL];
+                NSFileManager *fm = [NSFileManager defaultManager];
+                if ([fm fileExistsAtPath:storeDirURL.path]) {
+                    if (![fm removeItemAtURL:storeDirURL error:&error]) {
+                        NSLog(@"Unable to delete SQLite db files directory at %@ : error %@, %@", storeDirURL, error, [error userInfo]);
+                        return;
+                    }
                 }
             }
             


### PR DESCRIPTION
not sure when it appeared, wasn’t preventing tests from passing travis-ci but was logging scary errors about unlinking files while in use