### PR TITLE
make travis build docs on tags

### DIFF
--- a/travis/build.sh
+++ b/travis/build.sh
@@ -2,12 +2,12 @@
 set -ex
 # setup config file for integration tests
 cp BridgeAdminCredentials.plist ../BridgeAdminCredentials.plist
-if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then     # on pull requests
-    bundle exec fastlane doc scheme:"BridgeSDK"
+# build docs
+bundle exec fastlane doc scheme:"BridgeSDK"
+if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then     # on pull requests
     # secrets not available on PR builds so need to exclude integration tests
     FASTLANE_EXPLICIT_OPEN_SIMULATOR=2 bundle exec fastlane test scheme:"BridgeSDK" only_testing:"BridgeSDKTests"
 elif [[ -z "$TRAVIS_TAG" && "$TRAVIS_BRANCH" == "master" ]]; then  # non-tag commits to master branch
-    bundle exec fastlane doc scheme:"BridgeSDK"
     FASTLANE_EXPLICIT_OPEN_SIMULATOR=2 bundle exec fastlane test scheme:"BridgeSDK" # run all tests
 fi
 exit $?


### PR DESCRIPTION
Travis was not building the docs when a tag is pushed therefore
the build would fail with 'No such file or directory @ dir_chdir -
Documentation'.  This update will build the docs so the deploy
will work.