### PR TITLE
[BRIDGE-2282] fix apple doc generation

### DIFF
--- a/travis/install-appledoc.sh
+++ b/travis/install-appledoc.sh
@@ -1,3 +1,9 @@
 #!/bin/sh
 set -ex
-brew install appledoc
+# version from brew is borked, https://github.com/tomaz/appledoc/issues/596
+# brew install appledoc
+git clone git://github.com/tomaz/appledoc.git ~/appledoc
+pushd ~/appledoc
+./install-appledoc.sh -t ~/.appledoc
+popd
+


### PR DESCRIPTION
TThe appledoc version from brew doesn't generate all files[1].
Using the latest version from Github fixes this issue.

[1] https://github.com/tomaz/appledoc/issues/596