### PR TITLE
fix integration tests

### DIFF
--- a/BridgeSDK.xcodeproj/xcshareddata/xcschemes/BridgeSDK.xcscheme
+++ b/BridgeSDK.xcodeproj/xcshareddata/xcschemes/BridgeSDK.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "NO">
       <PreActions>
          <ExecutionAction

--- a/BridgeSDKTests/SBBConsentManagerIntegrationTests.m
+++ b/BridgeSDKTests/SBBConsentManagerIntegrationTests.m
@@ -29,8 +29,8 @@
     [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
     
-    self.testSubpopOptionalGuid = @"0c132b61-f5fd-4e75-9813-5b7dce04cdd7";
-    self.testSubpopRequiredGuid = @"cfbbbaed-bf7a-4b20-aad8-f649a7e6e7fc";
+    self.testSubpopOptionalGuid = @"e0a13185-90b3-4e24-9007-9505de46a389";
+    self.testSubpopRequiredGuid = @"72d3d10f-1a59-4bd2-8d3f-997bb458bcd3";
 }
 
 - (void)tearDown {


### PR DESCRIPTION
Test study subpopulation consent docs somehow got deleted. Fix required deleting and re-creating the subpopulations, which means new guids.

Also turning on code coverage collection during tests.