### PR TITLE
Revert "Clear password on auth failure"

### DIFF
--- a/BridgeSDK/BridgeAPI/SBBAuthManager.m
+++ b/BridgeSDK/BridgeAPI/SBBAuthManager.m
@@ -513,16 +513,13 @@ void dispatchSyncToKeychainQueue(dispatch_block_t dispatchBlock)
         return;
     }
     
-    // check for cases where we need to discard the sessionToken, reauthToken, and password:
-    // • SBBErrorCodeServerNotAuthenticated (auth failed)
-    // • 404 (no such account, at least not verified)
-    // • SBBErrorCodeServerAccountDisabled (account has been disabled)
+    // check for cases where we need to discard the sessionToken and reauthToken: SBBErrorCodeServerNotAuthenticated (auth failed),
+    // 404 (no such account, at least not verified), SBBErrorCodeServerAccountDisabled (account has been disabled)
     if (error.code == SBBErrorCodeServerNotAuthenticated ||
         error.code == 404 ||
         error.code == SBBErrorCodeServerAccountDisabled) {
         [self clearSessionToken];
         [self clearReauthToken];
-        [self clearPassword];
         [self resetUserSessionInfo];
     }
 
@@ -1041,11 +1038,6 @@ void dispatchSyncToKeychainQueue(dispatch_block_t dispatchBlock)
 - (void)clearReauthToken
 {
     [self.keychainManager removeValuesForKeys:@[ self.reauthTokenKey ]];
-}
-
-- (void)clearPassword
-{
-    [self.keychainManager removeValuesForKeys:@[ self.passwordKey ]];
 }
 
 @end


### PR DESCRIPTION
This reverts commit 903f74521ecd432e042a609d6d54f84007cf5a9f.

Hi, in the app I'm developing, when the reauthentication fails, we don't display sign in form to the participant, but we fallback to the old email/password auth method based on the password stored in the Bridge's keychain. That's why I would like to revert a commit that introduces a logic that clears the password on auth failure.