### PR TITLE
Fix reauthentication with credential/password method

### DIFF
--- a/BridgeSDK/BridgeAPI/SBBAuthManager.m
+++ b/BridgeSDK/BridgeAPI/SBBAuthManager.m
@@ -561,13 +561,13 @@ void dispatchSyncToKeychainQueue(dispatch_block_t dispatchBlock)
         dispatchSyncToAuthAttemptQueue(^{
             [self clearSessionToken];
             [self clearReauthToken];
-            [self resetUserSessionInfo];
             if (error.code != SBBErrorCodeServerNotAuthenticated) {
                 // If the account itself is bad, and not just the reauth token, clear any saved password
                 // and credential as well.
                 [self clearPassword];
                 [self clearCredential];
             }
+            [self resetUserSessionInfo];
         });
     }
 
@@ -1069,7 +1069,7 @@ void dispatchSyncToKeychainQueue(dispatch_block_t dispatchBlock)
 
 - (BOOL)canAuthenticate
 {
-    return (self.savedReauthToken.length > 0);
+    return (self.savedReauthToken.length > 0) || (self.savedPassword.length > 0);
 }
 
 - (void)addAuthHeaderToHeaders:(NSMutableDictionary *)headers

--- a/BridgeSDK/BridgeAPI/SBBAuthManager.m
+++ b/BridgeSDK/BridgeAPI/SBBAuthManager.m
@@ -1069,7 +1069,12 @@ void dispatchSyncToKeychainQueue(dispatch_block_t dispatchBlock)
 
 - (BOOL)canAuthenticate
 {
-    return (self.savedReauthToken.length > 0) || (self.savedPassword.length > 0);
+    return (self.savedReauthToken.length > 0) || ((self.savedPassword.length > 0) && (self.hasSavedCredential));
+}
+
+- (BOOL)hasSavedCredential
+{
+    return (self.credentialKeyFromKeychain.length > 0 ) && (self.credentialValueFromKeychain.length > 0 );
 }
 
 - (void)addAuthHeaderToHeaders:(NSMutableDictionary *)headers


### PR DESCRIPTION
Hi, in the application I am working on, when reauthentication fails, a sign in form is not displayed to the participant, but the user is reauthenticated using email/password method. When the password is cleared by the Bridge SDK, our custom application's logic attempts to provide credentials in **kSBBUserSessionUpdatedNotification**. Therefore, I would like to move **resetUserSessionInfo** call after the logic that clears the tokens, password and credentials. Another change request is to modify **canAuthenticated** method to return **true**  if there is a password stored by the Bridge SDK, since **attemptSignInWithStoredCredentialsWithCompletion:** method supports reauthentication based on a password.